### PR TITLE
Mumu模擬器-global支持

### DIFF
--- a/build_log.txt
+++ b/build_log.txt
@@ -1,0 +1,542 @@
+﻿Updated iaa\__meta__.py with version 26.05b2
+Backend: pyinstaller
+Version: 26.05b2
+Timestamp: 2026-06-16-12-25-19
+Dist directory: D:\Tools\ichikas-auto-assistant\dist_app\v26.05b2_2026-06-16-12-25-19
+Spec: D:\Tools\ichikas-auto-assistant\iaa.spec
+Building with PyInstaller...
+Running command: D:\Tools\ichikas-auto-assistant\.venv\Scripts\python.exe -m PyInstaller --clean --noconfirm --distpath=D:\Tools\ichikas-auto-assistant\build --workpath=D:\Tools\ichikas-auto-assistant\build\work D:\Tools\ichikas-auto-assistant\iaa.spec
+183 INFO: PyInstaller: 6.19.0, contrib hooks: 2026.4
+183 INFO: Python: 3.10.20
+198 INFO: Platform: Windows-10-10.0.26200-SP0
+198 INFO: Python environment: D:\Tools\ichikas-auto-assistant\.venv
+201 INFO: Removing temporary files and cleaning cache in C:\Users\yammy\AppData\Local\pyinstaller
+470 WARNING: Failed to collect submodules for 'uiautomator2.ext.info' because importing 'uiautomator2.ext.info' raised: ImportError: cannot import name 'UIAutomatorServer' from 'uiautomator2' (D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\uiautomator2\__init__.py)
+289 WARNING: Failed to collect submodules for 'PySide6.scripts.deploy_lib' because importing 'PySide6.scripts.deploy_lib' raised: ModuleNotFoundError: No module named 'project_lib'
+9870 INFO: Module search paths (PYTHONPATH):
+['D:\\Tools\\ichikas-auto-assistant',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\python310.zip',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\DLLs',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\lib',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none',
+ 'D:\\Tools\\ichikas-auto-assistant\\.venv',
+ 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages',
+ 'D:\\Tools\\ichikas-auto-assistant']
+308 WARNING: discover_hook_directories: Failed to process hook entry point 'EntryPoint(name='hook-dirs', value='rapidfuzz.__pyinstaller:get_hook_dirs', group='pyinstaller40')': AttributeError: module 'rapidfuzz.__pyinstaller' has no attribute 'get_hook_dirs'
+10438 INFO: Appending 'binaries' from .spec
+10511 INFO: Appending 'datas' from .spec
+11528 INFO: checking Analysis
+11528 INFO: Building Analysis because Analysis-00.toc is non existent
+11528 INFO: Looking for Python shared library...
+11528 INFO: Using Python shared library: C:\Users\yammy\AppData\Roaming\uv\python\cpython-3.10-windows-x86_64-none\python310.dll
+11528 INFO: Running Analysis Analysis-00.toc
+11528 INFO: Target bytecode optimization level: 0
+11528 INFO: Initializing module dependency graph...
+11530 INFO: Initializing module graph hook caches...
+11554 INFO: Analyzing modules for base_library.zip ...
+12502 INFO: Processing standard module hook 'hook-heapq.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+12584 INFO: Processing standard module hook 'hook-encodings.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+13970 INFO: Processing standard module hook 'hook-pickle.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+15173 INFO: Caching module dependency graph...
+15231 INFO: Analyzing D:\Tools\ichikas-auto-assistant\launch_desktop.py
+15278 INFO: Processing standard module hook 'hook-platform.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+15292 INFO: Processing standard module hook 'hook-PySide6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+15563 INFO: Processing standard module hook 'hook-shiboken6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+15722 INFO: Processing standard module hook 'hook-PySide6.QtNetwork.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+18130 INFO: Processing standard module hook 'hook-PySide6.QtCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+21808 INFO: Processing standard module hook 'hook-PySide6.QtGui.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+39037 INFO: Processing standard module hook 'hook-PySide6.QtWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+42415 INFO: Processing standard module hook 'hook-cv2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+43000 INFO: Processing standard module hook 'hook-numpy.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+43532 INFO: Processing standard module hook 'hook-difflib.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+43676 INFO: Processing standard module hook 'hook-multiprocessing.util.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+43840 INFO: Processing standard module hook 'hook-xml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+44101 INFO: Processing standard module hook 'hook-_ctypes.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+44484 INFO: Processing standard module hook 'hook-sysconfig.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+45239 INFO: Processing standard module hook 'hook-psutil.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+46552 INFO: Processing pre-safe-import-module hook 'hook-typing_extensions.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+46554 INFO: SetuptoolsInfo: initializing cached setuptools info...
+47452 INFO: Processing standard module hook 'hook-adbutils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+47467 INFO: Processing pre-safe-import-module hook 'hook-packaging.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+47552 INFO: Processing standard module hook 'hook-PIL.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+47633 INFO: Processing standard module hook 'hook-PIL.Image.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+48359 INFO: Processing standard module hook 'hook-PIL.ImageFilter.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+48388 INFO: Processing standard module hook 'hook-urllib3.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+49013 INFO: Processing standard module hook 'hook-charset_normalizer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+49160 INFO: Processing standard module hook 'hook-certifi.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+50102 INFO: Processing standard module hook 'hook-lxml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+50555 INFO: Processing standard module hook 'hook-lxml.etree.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+50592 INFO: Processing pre-safe-import-module hook 'hook-importlib_resources.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+50815 INFO: Processing standard module hook 'hook-av.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+51557 INFO: Processing standard module hook 'hook-pydantic.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\pydantic\experimental\__init__.py:7: PydanticExperimentalWarning: This module is experimental, its contents are subject to change and deprecation.
+  warnings.warn(
+52372 INFO: Processing standard module hook 'hook-rich.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+52571 INFO: Processing standard module hook 'hook-pygments.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+55028 INFO: Processing standard module hook 'hook-zoneinfo.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+55827 INFO: Processing standard module hook 'hook-uvicorn.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+56809 INFO: Processing standard module hook 'hook-websockets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+57827 INFO: Processing standard module hook 'hook-anyio.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+59267 INFO: Processing standard module hook 'hook-onnxruntime.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+59356 INFO: Processing standard module hook 'hook-shapely.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+59860 INFO: Processing pre-safe-import-module hook 'hook-tomli.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+60539 INFO: Processing standard module hook 'hook-sentry_sdk.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+61702 INFO: Processing standard module hook 'hook-PySide6.QtQuick.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+65247 INFO: Processing standard module hook 'hook-PySide6.QtOpenGL.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+69415 INFO: Processing standard module hook 'hook-PySide6.QtQml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+120952 INFO: Processing standard module hook 'hook-pynput.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+121499 INFO: Processing pre-safe-import-module hook 'hook-six.moves.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+121682 INFO: Processing standard module hook 'hook-PySide6.QtQuickControls2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+122714 INFO: Analyzing hidden import 'kaa'
+122716 INFO: Analyzing hidden import 'iaa.res'
+122716 INFO: Analyzing hidden import 'plyer.platforms.win.notification'
+122737 INFO: Analyzing hidden import 'kotonebot.backend.debug.entry'
+122741 INFO: Analyzing hidden import 'kotonebot.backend.debug.mock'
+122744 INFO: Analyzing hidden import 'kotonebot.backend.dispatch'
+122756 INFO: Analyzing hidden import 'kotonebot.client.fast_screenshot'
+122767 INFO: Analyzing hidden import 'kotonebot.client.host.windows_common'
+122793 INFO: Analyzing hidden import 'kotonebot.devtools.cli'
+123945 INFO: Analyzing hidden import 'kotonebot.devtools.mirror'
+123963 INFO: Analyzing hidden import 'uiautomator2.__main__'
+123973 INFO: Analyzing hidden import 'uiautomator2.ext'
+123974 INFO: Analyzing hidden import 'uiautomator2.ext.htmlreport'
+123982 INFO: Analyzing hidden import 'uiautomator2.ext.perf'
+124002 INFO: Analyzing hidden import 'av.__main__'
+124005 INFO: Analyzing hidden import 'av.bytesource'
+124006 INFO: Analyzing hidden import 'av.container.pyio'
+124007 INFO: Analyzing hidden import 'av.datasets'
+124011 INFO: Analyzing hidden import 'av.dictionary'
+124014 INFO: Analyzing hidden import 'av.opaque'
+124015 INFO: Analyzing hidden import 'av.utils'
+124017 INFO: Analyzing hidden import 'av.video.reformatter'
+124019 INFO: Analyzing hidden import 'PySide6.Qt3DAnimation'
+124054 INFO: Processing standard module hook 'hook-PySide6.Qt3DAnimation.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+125346 INFO: Processing standard module hook 'hook-PySide6.Qt3DCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+126879 INFO: Processing standard module hook 'hook-PySide6.Qt3DRender.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+134078 INFO: Analyzing hidden import 'PySide6.Qt3DExtras'
+134161 INFO: Processing standard module hook 'hook-PySide6.Qt3DExtras.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+135891 INFO: Analyzing hidden import 'PySide6.Qt3DInput'
+135916 INFO: Processing standard module hook 'hook-PySide6.Qt3DInput.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+137283 INFO: Analyzing hidden import 'PySide6.Qt3DLogic'
+137285 INFO: Processing standard module hook 'hook-PySide6.Qt3DLogic.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+138573 INFO: Analyzing hidden import 'PySide6.QtAsyncio'
+138612 INFO: Analyzing hidden import 'PySide6.QtAxContainer'
+138625 INFO: Processing standard module hook 'hook-PySide6.QtAxContainer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+139753 INFO: Analyzing hidden import 'PySide6.QtBluetooth'
+139851 INFO: Processing standard module hook 'hook-PySide6.QtBluetooth.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+140850 INFO: Analyzing hidden import 'PySide6.QtCanvasPainter'
+140902 INFO: Analyzing hidden import 'PySide6.QtCharts'
+141036 INFO: Processing standard module hook 'hook-PySide6.QtCharts.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+143485 INFO: Analyzing hidden import 'PySide6.QtConcurrent'
+143587 INFO: Processing standard module hook 'hook-PySide6.QtConcurrent.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+144248 INFO: Analyzing hidden import 'PySide6.QtDBus'
+144292 INFO: Processing standard module hook 'hook-PySide6.QtDBus.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+145833 INFO: Analyzing hidden import 'PySide6.QtDataVisualization'
+146007 INFO: Processing standard module hook 'hook-PySide6.QtDataVisualization.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+147897 INFO: Analyzing hidden import 'PySide6.QtDesigner'
+147941 INFO: Processing standard module hook 'hook-PySide6.QtDesigner.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+153462 INFO: Analyzing hidden import 'PySide6.QtGraphs'
+153704 INFO: Processing standard module hook 'hook-PySide6.QtGraphs.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+156572 INFO: Analyzing hidden import 'PySide6.QtGraphsWidgets'
+156603 INFO: Processing standard module hook 'hook-PySide6.QtGraphsWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+157379 INFO: Processing standard module hook 'hook-PySide6.QtQuickWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+158750 INFO: Analyzing hidden import 'PySide6.QtHelp'
+158778 INFO: Processing standard module hook 'hook-PySide6.QtHelp.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+160084 INFO: Analyzing hidden import 'PySide6.QtHttpServer'
+160113 INFO: Processing standard module hook 'hook-PySide6.QtHttpServer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+161315 INFO: Analyzing hidden import 'PySide6.QtLocation'
+161410 INFO: Processing standard module hook 'hook-PySide6.QtLocation.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+164173 INFO: Processing standard module hook 'hook-PySide6.QtPositioning.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+167903 INFO: Analyzing hidden import 'PySide6.QtMultimedia'
+168033 INFO: Processing standard module hook 'hook-PySide6.QtMultimedia.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+172721 INFO: Analyzing hidden import 'PySide6.QtMultimediaWidgets'
+172743 INFO: Processing standard module hook 'hook-PySide6.QtMultimediaWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+174426 INFO: Analyzing hidden import 'PySide6.QtNetworkAuth'
+174557 INFO: Processing standard module hook 'hook-PySide6.QtNetworkAuth.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+176517 INFO: Analyzing hidden import 'PySide6.QtNfc'
+176555 INFO: Processing standard module hook 'hook-PySide6.QtNfc.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+177917 INFO: Analyzing hidden import 'PySide6.QtOpenGLWidgets'
+177944 INFO: Processing standard module hook 'hook-PySide6.QtOpenGLWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+179261 INFO: Analyzing hidden import 'PySide6.QtPdf'
+179306 INFO: Processing standard module hook 'hook-PySide6.QtPdf.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+180817 INFO: Analyzing hidden import 'PySide6.QtPdfWidgets'
+180895 INFO: Processing standard module hook 'hook-PySide6.QtPdfWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+182078 INFO: Analyzing hidden import 'PySide6.QtPrintSupport'
+182107 INFO: Processing standard module hook 'hook-PySide6.QtPrintSupport.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+183620 INFO: Analyzing hidden import 'PySide6.QtQuick3D'
+183693 INFO: Processing standard module hook 'hook-PySide6.QtQuick3D.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+185564 INFO: Analyzing hidden import 'PySide6.QtQuickTest'
+185582 INFO: Analyzing hidden import 'PySide6.QtRemoteObjects'
+185605 INFO: Processing standard module hook 'hook-PySide6.QtRemoteObjects.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+186958 INFO: Analyzing hidden import 'PySide6.QtScxml'
+187002 INFO: Processing standard module hook 'hook-PySide6.QtScxml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+188734 INFO: Analyzing hidden import 'PySide6.QtSensors'
+188791 INFO: Processing standard module hook 'hook-PySide6.QtSensors.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+190860 INFO: Analyzing hidden import 'PySide6.QtSerialBus'
+190931 INFO: Processing standard module hook 'hook-PySide6.QtSerialBus.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+194596 INFO: Analyzing hidden import 'PySide6.QtSerialPort'
+194733 INFO: Processing standard module hook 'hook-PySide6.QtSerialPort.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+196146 INFO: Analyzing hidden import 'PySide6.QtSpatialAudio'
+196179 INFO: Processing standard module hook 'hook-PySide6.QtSpatialAudio.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+197823 INFO: Analyzing hidden import 'PySide6.QtSql'
+197910 INFO: Processing standard module hook 'hook-PySide6.QtSql.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+201560 INFO: Analyzing hidden import 'PySide6.QtStateMachine'
+201595 INFO: Processing standard module hook 'hook-PySide6.QtStateMachine.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+202789 INFO: Analyzing hidden import 'PySide6.QtSvg'
+202809 INFO: Processing standard module hook 'hook-PySide6.QtSvg.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+204071 INFO: Analyzing hidden import 'PySide6.QtSvgWidgets'
+204076 INFO: Processing standard module hook 'hook-PySide6.QtSvgWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+205425 INFO: Analyzing hidden import 'PySide6.QtTest'
+205450 INFO: Processing standard module hook 'hook-PySide6.QtTest.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+206839 INFO: Analyzing hidden import 'PySide6.QtTextToSpeech'
+206914 INFO: Processing standard module hook 'hook-PySide6.QtTextToSpeech.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+209423 INFO: Analyzing hidden import 'PySide6.QtUiTools'
+209449 INFO: Processing standard module hook 'hook-PySide6.QtUiTools.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+210740 INFO: Analyzing hidden import 'PySide6.QtWebChannel'
+210744 INFO: Processing standard module hook 'hook-PySide6.QtWebChannel.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+211914 INFO: Analyzing hidden import 'PySide6.QtWebEngineCore'
+212003 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+217188 INFO: Analyzing hidden import 'PySide6.QtWebEngineQuick'
+217221 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineQuick.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+218980 INFO: Analyzing hidden import 'PySide6.QtWebEngineWidgets'
+219061 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+220769 INFO: Analyzing hidden import 'PySide6.QtWebSockets'
+220794 INFO: Processing standard module hook 'hook-PySide6.QtWebSockets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+221929 INFO: Analyzing hidden import 'PySide6.QtWebView'
+221944 INFO: Analyzing hidden import 'PySide6.QtXml'
+221981 INFO: Processing standard module hook 'hook-PySide6.QtXml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+223142 INFO: Analyzing hidden import 'PySide6._config'
+223207 INFO: Analyzing hidden import 'PySide6._git_pyside_version'
+223210 INFO: Analyzing hidden import 'PySide6.scripts'
+223211 INFO: Analyzing hidden import 'PySide6.scripts.deploy'
+223219 INFO: Analyzing hidden import 'PySide6.scripts.metaobjectdump'
+223235 INFO: Analyzing hidden import 'PySide6.scripts.project'
+223251 INFO: Analyzing hidden import 'PySide6.scripts.project_lib'
+223340 INFO: Processing standard module hook 'hook-xml.etree.cElementTree.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+223380 INFO: Analyzing hidden import 'PySide6.scripts.pyside_tool'
+223388 INFO: Analyzing hidden import 'PySide6.scripts.qml'
+223395 INFO: Analyzing hidden import 'PySide6.scripts.qtpy2cpp'
+223407 INFO: Analyzing hidden import 'PySide6.support'
+223408 INFO: Analyzing hidden import 'PySide6.support.deprecated'
+223410 INFO: Analyzing hidden import 'PySide6.support.generate_pyi'
+223414 INFO: Processing module hooks (post-graph stage)...
+224107 INFO: Processing standard module hook 'hook-lxml.isoschematron.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+226425 INFO: Processing standard module hook 'hook-jinja2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+228374 WARNING: Hidden import "tzdata" not found!
+229354 INFO: Processing standard module hook 'hook-PIL.SpiderImagePlugin.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+235066 INFO: Processing standard module hook 'hook-lxml.objectify.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+235219 INFO: Performing binary vs. data reclassification (4191 entries)
+244891 INFO: Looking for ctypes DLLs
+245036 INFO: Analyzing run-time hooks ...
+245051 INFO: Including run-time hook 'pyi_rth_inspect.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+245074 INFO: Including run-time hook 'pyi_rth_pkgutil.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+245078 INFO: Including run-time hook 'pyi_rth_multiprocessing.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+245082 INFO: Including run-time hook 'pyi_rth_pyside6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+245084 INFO: Processing pre-find-module-path hook 'hook-_pyi_rth_utils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path'
+245119 INFO: Processing standard module hook 'hook-_pyi_rth_utils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+245345 INFO: Creating base_library.zip...
+245371 INFO: Looking for dynamic libraries
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\PyInstaller\building\build_main.py:227: UserWarning: The numpy.array_api submodule is still experimental. See NEP 47.
+  __import__(package)
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\pydantic\experimental\__init__.py:7: PydanticExperimentalWarning: This module is experimental, its contents are subject to change and deprecation.
+  warnings.warn(
+gc:0: ResourceWarning: gc: 21 uncollectable objects at shutdown; use gc.set_debug(gc.DEBUG_UNCOLLECTABLE) to list them
+257427 INFO: Extra DLL search directories (AddDllDirectory): ['D:\\Tools\\ichikas-auto-assistant\\.venv\\Lib\\site-packages\\shiboken6', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\av.libs', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\cv2', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\shapely.libs']
+257427 INFO: Extra DLL search directories (PATH): ['D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\cv2', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\Lib\\site-packages\\PySide6']
+274515 WARNING: Library not found: could not resolve 'fbclient.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlibase.dll'.
+274524 WARNING: Library not found: could not resolve 'MIMAPI64.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlmimer.dll'.
+274525 WARNING: Library not found: could not resolve 'OCI.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqloci.dll'.
+274530 WARNING: Library not found: could not resolve 'LIBPQ.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlpsql.dll'.
+274652 WARNING: Library not found: could not resolve 'Qt6QuickShapesDesignHelpers.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\qml\\QtQuick\\Shapes\\DesignHelpers\\qtquickshapesdesignhelpersplugin.dll'.
+275775 INFO: Warnings written to D:\Tools\ichikas-auto-assistant\build\work\iaa\warn-iaa.txt
+276086 INFO: Graph cross-reference written to D:\Tools\ichikas-auto-assistant\build\work\iaa\xref-iaa.html
+276458 INFO: checking PYZ
+276459 INFO: Building PYZ because PYZ-00.toc is non existent
+276459 INFO: Building PYZ (ZlibArchive) D:\Tools\ichikas-auto-assistant\build\work\iaa\PYZ-00.pyz
+278021 INFO: Building PYZ (ZlibArchive) D:\Tools\ichikas-auto-assistant\build\work\iaa\PYZ-00.pyz completed successfully.
+278109 INFO: checking PKG
+278109 INFO: Building PKG because PKG-00.toc is non existent
+278110 INFO: Building PKG (CArchive) iaa.pkg
+278155 INFO: Building PKG (CArchive) iaa.pkg completed successfully.
+278156 INFO: Bootloader D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\PyInstaller\bootloader\Windows-64bit-intel\run.exe
+278156 INFO: checking EXE
+278157 INFO: Building EXE because EXE-00.toc is non existent
+278157 INFO: Building EXE from EXE-00.toc
+278157 INFO: Copying bootloader EXE to D:\Tools\ichikas-auto-assistant\build\work\iaa\iaa.exe
+278188 INFO: Copying icon to EXE
+278193 INFO: Copying 0 resources to EXE
+278193 INFO: Embedding manifest in EXE
+278198 INFO: Appending PKG archive to EXE
+278208 INFO: Fixing EXE headers
+278441 INFO: Building EXE from EXE-00.toc completed successfully.
+508 WARNING: Failed to collect submodules for 'uiautomator2.ext.info' because importing 'uiautomator2.ext.info' raised: ImportError: cannot import name 'UIAutomatorServer' from 'uiautomator2' (D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\uiautomator2\__init__.py)
+470 WARNING: Failed to collect submodules for 'PySide6.scripts.deploy_lib' because importing 'PySide6.scripts.deploy_lib' raised: ModuleNotFoundError: No module named 'project_lib'
+290339 INFO: Module search paths (PYTHONPATH):
+['D:\\Tools\\ichikas-auto-assistant',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\python310.zip',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\DLLs',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none\\lib',
+ 'C:\\Users\\yammy\\AppData\\Roaming\\uv\\python\\cpython-3.10-windows-x86_64-none',
+ 'D:\\Tools\\ichikas-auto-assistant\\.venv',
+ 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages',
+ 'D:\\Tools\\ichikas-auto-assistant',
+ 'D:\\Tools\\ichikas-auto-assistant']
+401 WARNING: discover_hook_directories: Failed to process hook entry point 'EntryPoint(name='hook-dirs', value='rapidfuzz.__pyinstaller:get_hook_dirs', group='pyinstaller40')': AttributeError: module 'rapidfuzz.__pyinstaller' has no attribute 'get_hook_dirs'
+291196 INFO: Appending 'binaries' from .spec
+291291 INFO: Appending 'datas' from .spec
+292636 INFO: checking Analysis
+292637 INFO: Building Analysis because Analysis-01.toc is non existent
+292637 INFO: Looking for Python shared library...
+292637 INFO: Using Python shared library: C:\Users\yammy\AppData\Roaming\uv\python\cpython-3.10-windows-x86_64-none\python310.dll
+292637 INFO: Running Analysis Analysis-01.toc
+292637 INFO: Target bytecode optimization level: 0
+292637 INFO: Reusing cached module dependency graph...
+292672 INFO: Initializing module graph hook caches...
+292811 INFO: Analyzing D:\Tools\ichikas-auto-assistant\launch_cli.py
+292861 INFO: Processing pre-safe-import-module hook 'hook-typing_extensions.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+293055 INFO: Processing standard module hook 'hook-heapq.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+293092 INFO: Processing standard module hook 'hook-multiprocessing.util.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+293387 INFO: Processing standard module hook 'hook-xml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+293470 INFO: Processing standard module hook 'hook-pickle.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+293625 INFO: Processing standard module hook 'hook-_ctypes.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+294095 INFO: Processing standard module hook 'hook-cv2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+294894 INFO: Processing standard module hook 'hook-numpy.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+295762 INFO: Processing standard module hook 'hook-difflib.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+295888 INFO: Processing standard module hook 'hook-platform.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+295916 INFO: Processing standard module hook 'hook-sysconfig.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+296961 INFO: Processing standard module hook 'hook-psutil.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+298962 INFO: Processing standard module hook 'hook-adbutils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+298980 INFO: Processing pre-safe-import-module hook 'hook-packaging.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+299150 INFO: Processing standard module hook 'hook-PIL.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+299256 INFO: Processing standard module hook 'hook-PIL.Image.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+300313 INFO: Processing standard module hook 'hook-PIL.ImageFilter.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+300357 INFO: Processing standard module hook 'hook-urllib3.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+301211 INFO: Processing standard module hook 'hook-charset_normalizer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+301262 INFO: Processing standard module hook 'hook-encodings.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+301849 INFO: Processing standard module hook 'hook-certifi.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+303196 INFO: Processing standard module hook 'hook-lxml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+303767 INFO: Processing standard module hook 'hook-lxml.etree.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+303810 INFO: Processing pre-safe-import-module hook 'hook-importlib_resources.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+304061 INFO: Processing standard module hook 'hook-av.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+305108 INFO: Processing standard module hook 'hook-pydantic.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\pydantic\experimental\__init__.py:7: PydanticExperimentalWarning: This module is experimental, its contents are subject to change and deprecation.
+  warnings.warn(
+306080 INFO: Processing standard module hook 'hook-rich.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+306498 INFO: Processing standard module hook 'hook-pygments.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+309712 INFO: Processing standard module hook 'hook-zoneinfo.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+310904 INFO: Processing standard module hook 'hook-uvicorn.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+312205 INFO: Processing standard module hook 'hook-websockets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+313598 INFO: Processing standard module hook 'hook-anyio.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+315325 INFO: Processing standard module hook 'hook-onnxruntime.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+315525 INFO: Processing standard module hook 'hook-shapely.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+316064 INFO: Processing pre-safe-import-module hook 'hook-tomli.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+316803 INFO: Processing standard module hook 'hook-PySide6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+316811 INFO: Processing standard module hook 'hook-shiboken6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+317094 INFO: Processing standard module hook 'hook-PySide6.QtNetwork.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+318546 INFO: Processing standard module hook 'hook-PySide6.QtCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+319847 INFO: Processing standard module hook 'hook-PySide6.QtGui.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+321597 INFO: Processing standard module hook 'hook-PySide6.QtWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+321927 INFO: Processing standard module hook 'hook-sentry_sdk.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+323221 INFO: Processing standard module hook 'hook-PySide6.QtQuick.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+326415 INFO: Processing standard module hook 'hook-PySide6.QtOpenGL.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+326902 INFO: Processing standard module hook 'hook-PySide6.QtQml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+329851 INFO: Processing standard module hook 'hook-pynput.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+330358 INFO: Processing pre-safe-import-module hook 'hook-six.moves.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module'
+330514 INFO: Processing standard module hook 'hook-PySide6.QtQuickControls2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+330780 INFO: Analyzing hidden import 'kaa'
+330782 INFO: Analyzing hidden import 'iaa.res'
+330783 INFO: Analyzing hidden import 'plyer.platforms.win.notification'
+330797 INFO: Analyzing hidden import 'kotonebot.backend.debug.entry'
+330802 INFO: Analyzing hidden import 'kotonebot.backend.debug.mock'
+330805 INFO: Analyzing hidden import 'kotonebot.backend.dispatch'
+330816 INFO: Analyzing hidden import 'kotonebot.client.fast_screenshot'
+330825 INFO: Analyzing hidden import 'kotonebot.client.host.windows_common'
+330848 INFO: Analyzing hidden import 'kotonebot.devtools.cli'
+331820 INFO: Analyzing hidden import 'kotonebot.devtools.mirror'
+331833 INFO: Analyzing hidden import 'uiautomator2.__main__'
+331839 INFO: Analyzing hidden import 'uiautomator2.ext'
+331841 INFO: Analyzing hidden import 'uiautomator2.ext.htmlreport'
+331846 INFO: Analyzing hidden import 'uiautomator2.ext.perf'
+331861 INFO: Analyzing hidden import 'av.__main__'
+331862 INFO: Analyzing hidden import 'av.bytesource'
+331863 INFO: Analyzing hidden import 'av.container.pyio'
+331864 INFO: Analyzing hidden import 'av.datasets'
+331868 INFO: Analyzing hidden import 'av.dictionary'
+331870 INFO: Analyzing hidden import 'av.opaque'
+331870 INFO: Analyzing hidden import 'av.utils'
+331871 INFO: Analyzing hidden import 'av.video.reformatter'
+331874 INFO: Analyzing hidden import 'PySide6.Qt3DAnimation'
+331903 INFO: Processing standard module hook 'hook-PySide6.Qt3DAnimation.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+332367 INFO: Processing standard module hook 'hook-PySide6.Qt3DCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+332829 INFO: Processing standard module hook 'hook-PySide6.Qt3DRender.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+333353 INFO: Analyzing hidden import 'PySide6.Qt3DExtras'
+333441 INFO: Processing standard module hook 'hook-PySide6.Qt3DExtras.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+333766 INFO: Analyzing hidden import 'PySide6.Qt3DInput'
+333792 INFO: Processing standard module hook 'hook-PySide6.Qt3DInput.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+334136 INFO: Analyzing hidden import 'PySide6.Qt3DLogic'
+334139 INFO: Processing standard module hook 'hook-PySide6.Qt3DLogic.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+334472 INFO: Analyzing hidden import 'PySide6.QtAsyncio'
+334627 INFO: Analyzing hidden import 'PySide6.QtAxContainer'
+334646 INFO: Processing standard module hook 'hook-PySide6.QtAxContainer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+334978 INFO: Analyzing hidden import 'PySide6.QtBluetooth'
+335056 INFO: Processing standard module hook 'hook-PySide6.QtBluetooth.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+335364 INFO: Analyzing hidden import 'PySide6.QtCanvasPainter'
+335424 INFO: Analyzing hidden import 'PySide6.QtCharts'
+335557 INFO: Processing standard module hook 'hook-PySide6.QtCharts.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+335997 INFO: Analyzing hidden import 'PySide6.QtConcurrent'
+336003 INFO: Processing standard module hook 'hook-PySide6.QtConcurrent.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+336274 INFO: Analyzing hidden import 'PySide6.QtDBus'
+336314 INFO: Processing standard module hook 'hook-PySide6.QtDBus.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+336596 INFO: Analyzing hidden import 'PySide6.QtDataVisualization'
+336714 INFO: Processing standard module hook 'hook-PySide6.QtDataVisualization.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+337026 INFO: Analyzing hidden import 'PySide6.QtDesigner'
+337069 INFO: Processing standard module hook 'hook-PySide6.QtDesigner.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+337495 INFO: Analyzing hidden import 'PySide6.QtGraphs'
+337791 INFO: Processing standard module hook 'hook-PySide6.QtGraphs.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+338113 INFO: Analyzing hidden import 'PySide6.QtGraphsWidgets'
+338136 INFO: Processing standard module hook 'hook-PySide6.QtGraphsWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+338416 INFO: Processing standard module hook 'hook-PySide6.QtQuickWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+338719 INFO: Analyzing hidden import 'PySide6.QtHelp'
+338739 INFO: Processing standard module hook 'hook-PySide6.QtHelp.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+339043 INFO: Analyzing hidden import 'PySide6.QtHttpServer'
+339063 INFO: Processing standard module hook 'hook-PySide6.QtHttpServer.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+339360 INFO: Analyzing hidden import 'PySide6.QtLocation'
+339436 INFO: Processing standard module hook 'hook-PySide6.QtLocation.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+339992 INFO: Processing standard module hook 'hook-PySide6.QtPositioning.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+340369 INFO: Analyzing hidden import 'PySide6.QtMultimedia'
+340478 INFO: Processing standard module hook 'hook-PySide6.QtMultimedia.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+340950 INFO: Analyzing hidden import 'PySide6.QtMultimediaWidgets'
+340954 INFO: Processing standard module hook 'hook-PySide6.QtMultimediaWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+341269 INFO: Analyzing hidden import 'PySide6.QtNetworkAuth'
+341303 INFO: Processing standard module hook 'hook-PySide6.QtNetworkAuth.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+341599 INFO: Analyzing hidden import 'PySide6.QtNfc'
+341622 INFO: Processing standard module hook 'hook-PySide6.QtNfc.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+341945 INFO: Analyzing hidden import 'PySide6.QtOpenGLWidgets'
+341950 INFO: Processing standard module hook 'hook-PySide6.QtOpenGLWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+342262 INFO: Analyzing hidden import 'PySide6.QtPdf'
+342284 INFO: Processing standard module hook 'hook-PySide6.QtPdf.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+342612 INFO: Analyzing hidden import 'PySide6.QtPdfWidgets'
+342618 INFO: Processing standard module hook 'hook-PySide6.QtPdfWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+342930 INFO: Analyzing hidden import 'PySide6.QtPrintSupport'
+342952 INFO: Processing standard module hook 'hook-PySide6.QtPrintSupport.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+343253 INFO: Analyzing hidden import 'PySide6.QtQuick3D'
+343268 INFO: Processing standard module hook 'hook-PySide6.QtQuick3D.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+343586 INFO: Analyzing hidden import 'PySide6.QtQuickTest'
+343588 INFO: Analyzing hidden import 'PySide6.QtRemoteObjects'
+343613 INFO: Processing standard module hook 'hook-PySide6.QtRemoteObjects.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+344020 INFO: Analyzing hidden import 'PySide6.QtScxml'
+344042 INFO: Processing standard module hook 'hook-PySide6.QtScxml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+344384 INFO: Analyzing hidden import 'PySide6.QtSensors'
+344428 INFO: Processing standard module hook 'hook-PySide6.QtSensors.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+344787 INFO: Analyzing hidden import 'PySide6.QtSerialBus'
+344839 INFO: Processing standard module hook 'hook-PySide6.QtSerialBus.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+345228 INFO: Analyzing hidden import 'PySide6.QtSerialPort'
+345238 INFO: Processing standard module hook 'hook-PySide6.QtSerialPort.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+345528 INFO: Analyzing hidden import 'PySide6.QtSpatialAudio'
+345542 INFO: Processing standard module hook 'hook-PySide6.QtSpatialAudio.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+345842 INFO: Analyzing hidden import 'PySide6.QtSql'
+345890 INFO: Processing standard module hook 'hook-PySide6.QtSql.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+346282 INFO: Analyzing hidden import 'PySide6.QtStateMachine'
+346298 INFO: Processing standard module hook 'hook-PySide6.QtStateMachine.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+346584 INFO: Analyzing hidden import 'PySide6.QtSvg'
+346592 INFO: Processing standard module hook 'hook-PySide6.QtSvg.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+346890 INFO: Analyzing hidden import 'PySide6.QtSvgWidgets'
+346895 INFO: Processing standard module hook 'hook-PySide6.QtSvgWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+347222 INFO: Analyzing hidden import 'PySide6.QtTest'
+347251 INFO: Processing standard module hook 'hook-PySide6.QtTest.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+347569 INFO: Analyzing hidden import 'PySide6.QtTextToSpeech'
+347582 INFO: Processing standard module hook 'hook-PySide6.QtTextToSpeech.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+347931 INFO: Analyzing hidden import 'PySide6.QtUiTools'
+347934 INFO: Processing standard module hook 'hook-PySide6.QtUiTools.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+348230 INFO: Analyzing hidden import 'PySide6.QtWebChannel'
+348232 INFO: Processing standard module hook 'hook-PySide6.QtWebChannel.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+348530 INFO: Analyzing hidden import 'PySide6.QtWebEngineCore'
+348722 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineCore.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+349205 INFO: Analyzing hidden import 'PySide6.QtWebEngineQuick'
+349214 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineQuick.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+349518 INFO: Analyzing hidden import 'PySide6.QtWebEngineWidgets'
+349525 INFO: Processing standard module hook 'hook-PySide6.QtWebEngineWidgets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+349859 INFO: Analyzing hidden import 'PySide6.QtWebSockets'
+349875 INFO: Processing standard module hook 'hook-PySide6.QtWebSockets.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+350213 INFO: Analyzing hidden import 'PySide6.QtWebView'
+350220 INFO: Analyzing hidden import 'PySide6.QtXml'
+350253 INFO: Processing standard module hook 'hook-PySide6.QtXml.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+350589 INFO: Analyzing hidden import 'PySide6._config'
+350590 INFO: Analyzing hidden import 'PySide6._git_pyside_version'
+350592 INFO: Analyzing hidden import 'PySide6.scripts'
+350593 INFO: Analyzing hidden import 'PySide6.scripts.deploy'
+350600 INFO: Analyzing hidden import 'PySide6.scripts.metaobjectdump'
+350618 INFO: Analyzing hidden import 'PySide6.scripts.project'
+350636 INFO: Analyzing hidden import 'PySide6.scripts.project_lib'
+350721 INFO: Processing standard module hook 'hook-xml.etree.cElementTree.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+350763 INFO: Analyzing hidden import 'PySide6.scripts.pyside_tool'
+350773 INFO: Analyzing hidden import 'PySide6.scripts.qml'
+350783 INFO: Analyzing hidden import 'PySide6.scripts.qtpy2cpp'
+350788 INFO: Analyzing hidden import 'PySide6.support'
+350789 INFO: Analyzing hidden import 'PySide6.support.deprecated'
+350791 INFO: Analyzing hidden import 'PySide6.support.generate_pyi'
+350796 INFO: Processing module hooks (post-graph stage)...
+351339 INFO: Processing standard module hook 'hook-lxml.isoschematron.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+352411 INFO: Processing standard module hook 'hook-jinja2.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+353612 WARNING: Hidden import "tzdata" not found!
+354015 INFO: Processing standard module hook 'hook-PIL.SpiderImagePlugin.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+356992 INFO: Processing standard module hook 'hook-lxml.objectify.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\_pyinstaller_hooks_contrib\\stdhooks'
+357154 INFO: Performing binary vs. data reclassification (4191 entries)
+358814 INFO: Looking for ctypes DLLs
+358899 INFO: Analyzing run-time hooks ...
+358913 INFO: Including run-time hook 'pyi_rth_inspect.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+358916 INFO: Including run-time hook 'pyi_rth_pkgutil.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+358919 INFO: Including run-time hook 'pyi_rth_multiprocessing.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+358922 INFO: Including run-time hook 'pyi_rth_pyside6.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\rthooks'
+358924 INFO: Processing pre-find-module-path hook 'hook-_pyi_rth_utils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path'
+358926 INFO: Processing standard module hook 'hook-_pyi_rth_utils.py' from 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PyInstaller\\hooks'
+359158 INFO: Creating base_library.zip...
+359189 INFO: Looking for dynamic libraries
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\PyInstaller\building\build_main.py:227: UserWarning: The numpy.array_api submodule is still experimental. See NEP 47.
+  __import__(package)
+D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\pydantic\experimental\__init__.py:7: PydanticExperimentalWarning: This module is experimental, its contents are subject to change and deprecation.
+  warnings.warn(
+364720 INFO: Extra DLL search directories (AddDllDirectory): ['D:\\Tools\\ichikas-auto-assistant\\.venv\\Lib\\site-packages\\shiboken6', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\av.libs', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\cv2', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\shapely.libs']
+364720 INFO: Extra DLL search directories (PATH): ['D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\cv2', 'D:\\Tools\\ichikas-auto-assistant\\.venv\\Lib\\site-packages\\PySide6']
+378906 WARNING: Library not found: could not resolve 'fbclient.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlibase.dll'.
+378916 WARNING: Library not found: could not resolve 'MIMAPI64.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlmimer.dll'.
+378917 WARNING: Library not found: could not resolve 'OCI.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqloci.dll'.
+378922 WARNING: Library not found: could not resolve 'LIBPQ.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\plugins\\sqldrivers\\qsqlpsql.dll'.
+379043 WARNING: Library not found: could not resolve 'Qt6QuickShapesDesignHelpers.dll', dependency of 'D:\\Tools\\ichikas-auto-assistant\\.venv\\lib\\site-packages\\PySide6\\qml\\QtQuick\\Shapes\\DesignHelpers\\qtquickshapesdesignhelpersplugin.dll'.
+380651 INFO: Warnings written to D:\Tools\ichikas-auto-assistant\build\work\iaa\warn-iaa.txt
+381024 INFO: Graph cross-reference written to D:\Tools\ichikas-auto-assistant\build\work\iaa\xref-iaa.html
+381401 INFO: checking PYZ
+381402 INFO: Building PYZ because PYZ-01.toc is non existent
+381402 INFO: Building PYZ (ZlibArchive) D:\Tools\ichikas-auto-assistant\build\work\iaa\PYZ-01.pyz
+382738 INFO: Building PYZ (ZlibArchive) D:\Tools\ichikas-auto-assistant\build\work\iaa\PYZ-01.pyz completed successfully.
+382802 INFO: checking PKG
+382802 INFO: Building PKG because PKG-01.toc is non existent
+382802 INFO: Building PKG (CArchive) iaa-cli.pkg
+382826 INFO: Building PKG (CArchive) iaa-cli.pkg completed successfully.
+382828 INFO: Bootloader D:\Tools\ichikas-auto-assistant\.venv\lib\site-packages\PyInstaller\bootloader\Windows-64bit-intel\run.exe
+382829 INFO: checking EXE
+382829 INFO: Building EXE because EXE-01.toc is non existent
+382829 INFO: Building EXE from EXE-01.toc
+382830 INFO: Copying bootloader EXE to D:\Tools\ichikas-auto-assistant\build\work\iaa\iaa-cli.exe
+382837 INFO: Copying icon to EXE
+382845 INFO: Copying 0 resources to EXE
+382845 INFO: Embedding manifest in EXE
+382948 INFO: Appending PKG archive to EXE
+383057 INFO: Fixing EXE headers
+383178 INFO: Building EXE from EXE-01.toc completed successfully.
+383286 INFO: checking COLLECT
+383286 INFO: Building COLLECT because COLLECT-00.toc is non existent
+383286 INFO: Removing dir D:\Tools\ichikas-auto-assistant\build\iaa
+386205 INFO: Building COLLECT COLLECT-00.toc
+431231 INFO: Building COLLECT COLLECT-00.toc completed successfully.
+431390 INFO: Build complete! The results are available in: D:\Tools\ichikas-auto-assistant\build
+Built executables:
+  - D:\Tools\ichikas-auto-assistant\build\iaa\iaa.exe
+  - D:\Tools\ichikas-auto-assistant\build\iaa\iaa-cli.exe
+Copying runtime assets...
+Copying files to distribution directory...
+Cleaning up excluded PySide6 files...
+  Cleaned up PySide6: 536.7 MB removed
+Creating package...
+Packaged: D:\Tools\ichikas-auto-assistant\dist_app\iaa_v26.05b2_2026-06-16-12-25-19.zip
+Build completed successfully using pyinstaller!

--- a/iaa/application/qt/controllers/settings_controller.py
+++ b/iaa/application/qt/controllers/settings_controller.py
@@ -90,7 +90,7 @@ class SettingsController(QObject):
         self._iaa.config.shared = self._state.context.shared
 
     def _reload(self) -> None:
-        self._mumu_instances[:] = [{'id': '', 'label': DEFAULT_MUMU_INSTANCE_LABEL}]
+        self._mumu_instances[:] = [{'value': '', 'label': DEFAULT_MUMU_INSTANCE_LABEL}]
         self._state.reset(self._make_context())
         self._recompute_runtime()
         self.runtimeChanged.emit()
@@ -186,7 +186,7 @@ class SettingsController(QObject):
                 {'value': str(instance.id), 'label': f'[{instance.id}] {instance.name}'}
                 for instance in instances
             ]
-            ids = {item['id'] for item in items}
+            ids = {item['value'] for item in items}
             selected_id = ''
             if preferred_id and preferred_id in ids:
                 selected_id = preferred_id

--- a/iaa/application/qt/forms/preferences_form.py
+++ b/iaa/application/qt/forms/preferences_form.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
-from iaa.application.framework.dsl import Checkbox, FormPage, FormSpec, Group, Hotkey, Select, Text, bind
+from iaa.application.framework.dsl import Checkbox, FormPage, FormSpec, Group, Hotkey, Select, Text, bind, custom_ref
 from typing import Callable, cast
 from .context import PreferencesContext
 
 ctx, ref = bind(PreferencesContext)
+
+_push_command_ref = custom_ref(
+    lambda c: c.shared.notify.push.data.command if hasattr(c.shared.notify.push.data, 'command') else '',
+    lambda c, v: setattr(c.shared.notify.push.data, 'command', v) if hasattr(c.shared.notify.push.data, 'command') else None,
+)
+_push_webhook_url_ref = custom_ref(
+    lambda c: c.shared.notify.push.data.webhook_url if hasattr(c.shared.notify.push.data, 'webhook_url') else '',
+    lambda c, v: setattr(c.shared.notify.push.data, 'webhook_url', v) if hasattr(c.shared.notify.push.data, 'webhook_url') else None,
+)
+
+
+def _on_push_type_changed(context: PreferencesContext, value: str) -> None:
+    from iaa.config.shared import CustomPushData, DiscordPushData
+    if value == 'discord':
+        context.shared.notify.push.data = DiscordPushData()
+    else:
+        context.shared.notify.push.data = CustomPushData()
 
 
 def build_preferences_form() -> tuple[FormSpec[PreferencesContext], list[Callable[[PreferencesContext], None]]]:
@@ -70,12 +87,30 @@ def build_preferences_form() -> tuple[FormSpec[PreferencesContext], list[Callabl
                 label='推送通知',
                 ref=ref(ctx.shared.notify.push.enabled),
             )
+            Select(
+                key='notify.push.type',
+                label='推送类型',
+                ref=ref(ctx.shared.notify.push.type),
+                options=[
+                    {'value': 'custom', 'label': '自定义命令'},
+                    {'value': 'discord', 'label': 'Discord Webhook'},
+                ],
+                visible=lambda ctx: ctx.shared.notify.push.enabled,
+                on_change=_on_push_type_changed,
+            )
             Text(
                 key='notify.push.data.command',
                 label='自定义命令',
-                ref=ref(ctx.shared.notify.push.data.command),
+                ref=_push_command_ref,
                 placeholder='任务完成后执行的命令',
-                visible=lambda ctx: ctx.shared.notify.push.enabled,
+                visible=lambda ctx: ctx.shared.notify.push.enabled and ctx.shared.notify.push.type == 'custom',
+            )
+            Text(
+                key='notify.push.data.webhook_url',
+                label='Discord Webhook URL',
+                ref=_push_webhook_url_ref,
+                placeholder='https://discord.com/api/webhooks/...',
+                visible=lambda ctx: ctx.shared.notify.push.enabled and ctx.shared.notify.push.type == 'discord',
             )
 
         with Group('快捷键'):

--- a/iaa/application/service/custom_emulator.py
+++ b/iaa/application/service/custom_emulator.py
@@ -157,7 +157,7 @@ class CustomEmulatorInstance(CommonAdbCreateDeviceMixin, Instance[AdbHostConfig]
                             continue
                         app = d.app_current()
                         logger.debug('Waiting for launcher... (current=%s)', app)
-                        if app and 'launcher' in app.package:
+                        if app and 'launcher' in f'{app.package}{app.activity or ""}'.lower():
                             logger.info('Emulator %s(%s) now is available.', self.name, serial)
                             state = 6
                     case 6:

--- a/iaa/config/shared.py
+++ b/iaa/config/shared.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 
 class TelemetryConfig(BaseModel):
@@ -21,13 +21,30 @@ class CustomPushData(BaseModel):
     command: str = ''
 
 
-PushData = CustomPushData
+class DiscordPushData(BaseModel):
+    webhook_url: str = ''
+
+
+PushData = CustomPushData | DiscordPushData
 
 
 class PushConfig(BaseModel):
     enabled: bool = False
-    type: Literal['custom'] = 'custom'
-    data: CustomPushData = CustomPushData()
+    type: Literal['custom', 'discord'] = 'custom'
+    data: PushData = Field(default_factory=CustomPushData)
+
+    @model_validator(mode='before')
+    @classmethod
+    def _coerce_data(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            push_type = values.get('type', 'custom')
+            raw_data = values.get('data')
+            if isinstance(raw_data, dict):
+                if push_type == 'discord':
+                    values['data'] = DiscordPushData(**raw_data)
+                else:
+                    values['data'] = CustomPushData(**raw_data)
+        return values
 
 
 class NotifyConfig(BaseModel):

--- a/iaa/main.py
+++ b/iaa/main.py
@@ -23,6 +23,7 @@ class CliAction:
     debug_enabled: bool = False
     auto_live_kwargs: dict[str, object] | None = None
     help_text: str | None = None
+    mumu_instance: str | None = None
 
 
 def add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -75,7 +76,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest='command')
 
-    subparsers.add_parser('run', help='Run configured regular tasks')
+    run_parser = subparsers.add_parser('run', help='Run configured regular tasks')
+    run_parser.add_argument(
+        '--mumu-instance',
+        default=None,
+        metavar='ID',
+        help='Override MuMu instance ID from config (e.g. --mumu-instance 1)',
+    )
 
     invoke_parser = subparsers.add_parser('invoke', help='Run one or more tasks explicitly')
     invoke_parser.add_argument('task_ids', nargs='+', help='Task id(s) to run in order')
@@ -139,6 +146,7 @@ def parse_cli_action(argv: Sequence[str] | None = None) -> CliAction:
             kind='run_regular',
             config_name=args.config,
             debug_enabled=bool(args.debug),
+            mumu_instance=args.mumu_instance,
         )
 
     if args.command == 'invoke':
@@ -214,6 +222,12 @@ def execute_cli_action(action: CliAction) -> int:
 
     validate_cli_config_selection(action)
     iaa = IaaService(config_name=action.config_name)
+
+    if action.mumu_instance is not None:
+        from iaa.config.schemas import MuMuDevice
+        lc = iaa.config.conf.device.lifecycle
+        if isinstance(lc, MuMuDevice):
+            lc.instance_id = action.mumu_instance or None
 
     if action.kind == 'invoke_tasks':
         for task_id in action.task_ids:

--- a/iaa/notify.py
+++ b/iaa/notify.py
@@ -1,23 +1,61 @@
+import json
 import logging
 import subprocess
+import urllib.request
 
 from iaa.config.shared import NotifyConfig
 
 logger = logging.getLogger(__name__)
+
+_DISCORD_COLOR_SUCCESS = 0x57F287  # green
+_DISCORD_COLOR_FAILURE = 0xED4245  # red
+_DISCORD_COLOR_DEFAULT = 0x5865F2  # blurple
+
+_FAILURE_KEYWORDS = ('失败', '错误', '失敗', '錯誤', 'fail', 'error', 'failed')
+_SUCCESS_KEYWORDS = ('完成', '成功', 'done', 'success', 'finished', 'complete')
+
+
+def _infer_discord_color(title: str, message: str) -> int:
+    text = (title + ' ' + message).lower()
+    if any(k in text for k in _FAILURE_KEYWORDS):
+        return _DISCORD_COLOR_FAILURE
+    if any(k in text for k in _SUCCESS_KEYWORDS):
+        return _DISCORD_COLOR_SUCCESS
+    return _DISCORD_COLOR_DEFAULT
+
+
+def _send_discord(webhook_url: str, title: str, message: str) -> None:
+    if not webhook_url:
+        logger.warning('Discord webhook URL is empty')
+        return
+    color = _infer_discord_color(title, message)
+    payload = json.dumps(
+        {'embeds': [{'title': title, 'description': message, 'color': color}]}
+    ).encode()
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={'Content-Type': 'application/json'},
+        method='POST',
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        logger.debug('Discord webhook response: %s', resp.status)
 
 
 def send_notification(title: str, message: str, config: NotifyConfig) -> None:
     if config.system:
         try:
             from plyer import notification
-            notification.notify(title=title, message=message) # type: ignore
+            notification.notify(title=title, message=message)  # type: ignore
             logger.debug('System notification sent: %s - %s', title, message)
         except Exception:
             logger.exception('Failed to send system notification')
 
     if config.push.enabled:
         if config.push.type == 'custom':
-            command = config.push.data.command
+            from iaa.config.shared import CustomPushData
+            data = config.push.data
+            command = data.command if isinstance(data, CustomPushData) else ''
             if not command:
                 logger.warning('Push notification enabled but command is empty')
                 return
@@ -26,3 +64,14 @@ def send_notification(title: str, message: str, config: NotifyConfig) -> None:
                 logger.debug('Push notification command executed: %s', command)
             except Exception:
                 logger.exception('Failed to execute push notification command')
+        elif config.push.type == 'discord':
+            from iaa.config.shared import DiscordPushData
+            data = config.push.data
+            if not isinstance(data, DiscordPushData):
+                logger.warning('Discord push type set but data is not DiscordPushData')
+                return
+            try:
+                _send_discord(data.webhook_url, title, message)
+                logger.debug('Discord notification sent: %s - %s', title, message)
+            except Exception:
+                logger.exception('Failed to send Discord webhook notification')

--- a/patch_mumu12.py
+++ b/patch_mumu12.py
@@ -1,0 +1,338 @@
+"""
+patch_mumu12.py  —  Patch kotonebot.client.host.mumu12_host inside built IAA executables
+to support MuMu Player Global (international edition).
+
+Usage:
+    python patch_mumu12.py              # auto-finds latest dist_app/v*/
+    python patch_mumu12.py <dist_dir>   # use specific dist directory
+
+The script patches iaa.exe and iaa-cli.exe by replacing the embedded
+kotonebot.client.host.mumu12_host module in their PyInstaller archives.
+
+Idempotent: creates a .bak_mumu12 backup on first run; skips if backup exists.
+"""
+
+from __future__ import annotations
+
+import io
+import marshal
+import os
+import shutil
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+PATCH_SOURCE = REPO_ROOT / 'tools' / 'mumu12_host_patch.py'
+
+# Module name as it appears in the PYZ TOC (dot-separated)
+TARGET_MODULE = 'kotonebot.client.host.mumu12_host'
+
+BAK_SUFFIX = '.bak_mumu12'
+EXE_NAMES = ('iaa.exe', 'iaa-cli.exe')
+
+# ---------------------------------------------------------------------------
+# CArchive format constants (PyInstaller 6.x, big-endian)
+# ---------------------------------------------------------------------------
+_CA_MAGIC = b'MEI\014\013\012\013\016'
+_CA_COOKIE_FMT = '>8sIIII'   # magic + pkg_len + toc_pos + toc_size + pyver
+_CA_COOKIE_SIZE = struct.calcsize(_CA_COOKIE_FMT)  # 24 bytes
+
+_CA_ITEM_FMT = '>IIIIBc'     # entry_size + data_pos + data_size + usize + compress + typecode
+_CA_ITEM_HDR = struct.calcsize(_CA_ITEM_FMT)       # 18 bytes
+
+# PYZ archive format (ZlibArchive, big-endian)
+_PYZ_MAGIC = b'PYZ\x00'
+_PYZ_HDR_FMT = '>4sII'       # magic + pyver + toc_pos
+_PYZ_HDR_SIZE = struct.calcsize(_PYZ_HDR_FMT)      # 12 bytes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def find_latest_dist_dir() -> Path:
+    dist_base = REPO_ROOT / 'dist_app'
+    if not dist_base.exists():
+        raise FileNotFoundError(f'dist_app/ not found under {REPO_ROOT}')
+    candidates = sorted(dist_base.glob('v*/'), reverse=True)
+    if not candidates:
+        raise FileNotFoundError(f'No version directories found in {dist_base}')
+    return candidates[0]
+
+
+def compile_module(source_path: Path) -> bytes:
+    """Compile Python source to raw marshalled code object (no .pyc header)."""
+    source = source_path.read_text(encoding='utf-8')
+    code = compile(source, str(source_path.name), 'exec', optimize=0)
+    return marshal.dumps(code)
+
+
+# ---------------------------------------------------------------------------
+# CArchive parsing
+# ---------------------------------------------------------------------------
+
+def _parse_ca_cookie(data: bytes) -> tuple[int, int, int, int, int]:
+    """Return (archive_offset, toc_abs_offset, toc_size, pyver, pkg_len)."""
+    if len(data) < _CA_COOKIE_SIZE:
+        raise ValueError('File too small')
+    cookie = data[-_CA_COOKIE_SIZE:]
+    magic, pkg_len, toc_pos, toc_size, pyver = struct.unpack(_CA_COOKIE_FMT, cookie)
+    if magic != _CA_MAGIC:
+        raise ValueError(f'CArchive magic not found (got {magic!r})')
+    archive_offset = len(data) - pkg_len
+    toc_abs = archive_offset + toc_pos
+    return archive_offset, toc_abs, toc_size, pyver, pkg_len
+
+
+def _parse_ca_toc(data: bytes, toc_abs: int, toc_size: int) -> list[dict]:
+    entries: list[dict] = []
+    pos = toc_abs
+    end = toc_abs + toc_size
+    while pos < end:
+        if pos + _CA_ITEM_HDR > end:
+            break
+        entry_size, data_pos, data_size, usize, compress, typecode = struct.unpack_from(
+            _CA_ITEM_FMT, data, pos
+        )
+        name_bytes = data[pos + _CA_ITEM_HDR: pos + entry_size]
+        name = name_bytes.rstrip(b'\x00').decode('utf-8', errors='replace')
+        entries.append({
+            'entry_start': pos,
+            'entry_size': entry_size,
+            'data_pos': data_pos,
+            'data_size': data_size,
+            'usize': usize,
+            'compress': bool(compress),
+            'type': typecode.decode('ascii', errors='?'),
+            'name': name,
+        })
+        pos += entry_size
+    return entries
+
+
+def _extract_ca_entry(data: bytes, entry: dict, archive_offset: int) -> bytes:
+    start = archive_offset + entry['data_pos']
+    raw = data[start: start + entry['data_size']]
+    return zlib.decompress(raw) if entry['compress'] else raw
+
+
+def _find_pyz_entry(toc: list[dict]) -> dict:
+    for e in toc:
+        if e['type'] == 'z':
+            return e
+    # Fallback: look for an entry whose name ends with 'PYZ-00.pyz'
+    for e in toc:
+        if e['name'].endswith('.pyz'):
+            return e
+    raise ValueError('PYZ entry not found in CArchive TOC')
+
+
+# ---------------------------------------------------------------------------
+# PYZ (ZlibArchive) parsing
+# ---------------------------------------------------------------------------
+
+def _parse_pyz(pyz_data: bytes) -> tuple[int, int, dict]:
+    """Return (pyver, toc_pos, toc_dict).
+    toc_dict = {module_name: (type_code, offset, length)}
+    """
+    if not pyz_data.startswith(_PYZ_MAGIC):
+        raise ValueError(f'Not a PYZ archive (magic={pyz_data[:4]!r})')
+    _, pyver, toc_pos = struct.unpack_from(_PYZ_HDR_FMT, pyz_data)
+    toc = marshal.loads(pyz_data[toc_pos:])
+    return pyver, toc_pos, toc
+
+
+def _rebuild_pyz(original: bytes, toc: dict, replacements: dict[str, bytes]) -> bytes:
+    """Rebuild PYZ with replaced module bytecode.
+    replacements = {module_name: raw_marshalled_code}
+    """
+    buf = io.BytesIO()
+    buf.write(_PYZ_MAGIC)
+    buf.write(original[4:8])         # pyver field
+    buf.write(b'\x00\x00\x00\x00')  # toc_pos placeholder
+
+    new_toc: dict[str, tuple] = {}
+    for name, (type_code, offset, length) in toc.items():
+        pos = buf.tell()
+        if name in replacements:
+            compressed = zlib.compress(replacements[name], level=6)
+        else:
+            # Copy original compressed bytes
+            compressed = original[offset: offset + length]
+        buf.write(compressed)
+        new_toc[name] = (type_code, pos, len(compressed))
+
+    new_toc_pos = buf.tell()
+    buf.write(marshal.dumps(new_toc))
+
+    result = bytearray(buf.getvalue())
+    struct.pack_into('>I', result, 8, new_toc_pos)
+    return bytes(result)
+
+
+# ---------------------------------------------------------------------------
+# CArchive rebuild
+# ---------------------------------------------------------------------------
+
+def _rebuild_ca(pe_part: bytes, toc: list[dict], entry_data: dict[str, bytes], pyver: int) -> bytes:
+    """Reconstruct the CArchive portion (data + TOC + cookie) and append to pe_part."""
+    body = io.BytesIO()
+    new_toc: list[dict] = []
+
+    for entry in toc:
+        name = entry['name']
+        raw = entry_data[name]
+        data_pos = body.tell()
+        # Re-compress if original was compressed (keep same compression flag)
+        if entry['compress']:
+            stored = zlib.compress(raw, level=6)
+            is_comp = True
+        else:
+            stored = raw
+            is_comp = False
+        body.write(stored)
+        new_toc.append({**entry, 'data_pos': data_pos, 'data_size': len(stored),
+                         'usize': len(raw), 'compress': is_comp})
+
+    toc_pos = body.tell()
+
+    # Build TOC bytes
+    toc_buf = io.BytesIO()
+    for e in new_toc:
+        name_bytes = e['name'].encode('utf-8') + b'\x00'
+        entry_size = _CA_ITEM_HDR + len(name_bytes)
+        toc_buf.write(struct.pack(
+            _CA_ITEM_FMT,
+            entry_size,
+            e['data_pos'],
+            e['data_size'],
+            e['usize'],
+            1 if e['compress'] else 0,
+            e['type'].encode('ascii'),
+        ))
+        toc_buf.write(name_bytes)
+
+    toc_data = toc_buf.getvalue()
+    archive_body = body.getvalue() + toc_data
+    pkg_len = len(archive_body) + _CA_COOKIE_SIZE
+
+    cookie = struct.pack(_CA_COOKIE_FMT, _CA_MAGIC, pkg_len, toc_pos, len(toc_data), pyver)
+    return pe_part + archive_body + cookie
+
+
+# ---------------------------------------------------------------------------
+# Main patch routine
+# ---------------------------------------------------------------------------
+
+def patch_exe(exe_path: Path, new_code: bytes) -> None:
+    data = exe_path.read_bytes()
+
+    # 1. Locate CArchive
+    archive_offset, toc_abs, toc_size, pyver, pkg_len = _parse_ca_cookie(data)
+    pe_part = data[:archive_offset]
+
+    # 2. Parse CArchive TOC
+    ca_toc = _parse_ca_toc(data, toc_abs, toc_size)
+
+    # 3. Find and extract PYZ
+    pyz_entry = _find_pyz_entry(ca_toc)
+    pyz_data = _extract_ca_entry(data, pyz_entry, archive_offset)
+
+    # 4. Parse PYZ and replace the target module
+    pyz_pyver, pyz_toc_pos, pyz_toc = _parse_pyz(pyz_data)
+    if TARGET_MODULE not in pyz_toc:
+        raise KeyError(
+            f'{TARGET_MODULE!r} not found in PYZ.\n'
+            f'Available (sample): {list(pyz_toc)[:8]}'
+        )
+    new_pyz = _rebuild_pyz(pyz_data, pyz_toc, {TARGET_MODULE: new_code})
+
+    # 5. Rebuild all CArchive entry data (replacing PYZ)
+    entry_data: dict[str, bytes] = {}
+    for e in ca_toc:
+        if e['name'] == pyz_entry['name']:
+            entry_data[e['name']] = new_pyz
+        else:
+            entry_data[e['name']] = _extract_ca_entry(data, e, archive_offset)
+
+    # 6. Rebuild exe
+    new_exe = _rebuild_ca(pe_part, ca_toc, entry_data, pyver)
+    exe_path.write_bytes(new_exe)
+
+
+def main() -> None:
+    if not PATCH_SOURCE.exists():
+        print(f'ERROR: Patch source not found: {PATCH_SOURCE}', file=sys.stderr)
+        sys.exit(1)
+
+    # Find dist directory
+    if len(sys.argv) > 1:
+        dist_dir = Path(sys.argv[1])
+        if not dist_dir.is_dir():
+            print(f'ERROR: Directory not found: {dist_dir}', file=sys.stderr)
+            sys.exit(1)
+    else:
+        try:
+            dist_dir = find_latest_dist_dir()
+        except FileNotFoundError as e:
+            print(f'ERROR: {e}', file=sys.stderr)
+            sys.exit(1)
+
+    print(f'Dist directory : {dist_dir}')
+    print(f'Patch source   : {PATCH_SOURCE}')
+
+    # Compile replacement module
+    print('Compiling patch source...')
+    try:
+        new_code = compile_module(PATCH_SOURCE)
+    except SyntaxError as e:
+        print(f'ERROR: Syntax error in patch source: {e}', file=sys.stderr)
+        sys.exit(1)
+    print(f'  OK ({len(new_code)} bytes raw bytecode)')
+
+    patched = 0
+    skipped = 0
+
+    for exe_name in EXE_NAMES:
+        exe_path = dist_dir / exe_name
+        if not exe_path.exists():
+            print(f'[SKIP] {exe_name} — not found in {dist_dir}')
+            skipped += 1
+            continue
+
+        bak_path = Path(str(exe_path) + BAK_SUFFIX)
+        if bak_path.exists():
+            print(f'[SKIP] {exe_name} — already patched (backup exists at {bak_path.name})')
+            skipped += 1
+            continue
+
+        print(f'[PATCH] {exe_name} ...')
+
+        # Create backup (idempotent guard)
+        shutil.copy2(exe_path, bak_path)
+        print(f'  Backup: {bak_path.name}')
+
+        try:
+            patch_exe(exe_path, new_code)
+            size_orig = bak_path.stat().st_size
+            size_new = exe_path.stat().st_size
+            print(f'  Done. {size_orig:,} → {size_new:,} bytes')
+            patched += 1
+        except Exception as exc:
+            # Restore original on failure
+            shutil.copy2(bak_path, exe_path)
+            bak_path.unlink(missing_ok=True)
+            print(f'  ERROR: {exc}', file=sys.stderr)
+            import traceback
+            traceback.print_exc()
+
+    print()
+    print(f'Summary: {patched} patched, {skipped} skipped.')
+    if patched == 0 and skipped == len(EXE_NAMES):
+        print('Nothing to do — all executables already patched or not present.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/mumu12_host_patch.py
+++ b/tools/mumu12_host_patch.py
@@ -1,0 +1,349 @@
+"""
+Patched kotonebot.client.host.mumu12_host
+Adds support for MuMu Player Global (international edition).
+
+Extended path detection order:
+  1. MUMU_PATH environment variable
+  2. HKLM\\SOFTWARE\\Netease\\MuMuPlayer12              (CN, 64-bit)
+  3. HKLM\\SOFTWARE\\WOW6432Node\\Netease\\MuMuPlayer12 (CN, 32-bit on 64-bit)
+  4. HKLM\\SOFTWARE\\Netease\\MuMuPlayerGlobal          (Global, 64-bit)
+  5. HKLM\\SOFTWARE\\WOW6432Node\\Netease\\MuMuPlayerGlobal (Global, 32-bit)
+  6. Full disk scan as final fallback
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import subprocess
+import sys
+import winreg
+from pathlib import Path
+from typing import Any, ClassVar
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Registry key candidates (key, value_name) for MuMu install path
+# ---------------------------------------------------------------------------
+_REGISTRY_CANDIDATES: list[tuple[int, str, str]] = [
+    (winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\Netease\MuMuPlayer12', 'InstallDir'),
+    (winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\WOW6432Node\Netease\MuMuPlayer12', 'InstallDir'),
+    (winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\Netease\MuMuPlayerGlobal', 'InstallDir'),
+    (winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\WOW6432Node\Netease\MuMuPlayerGlobal', 'InstallDir'),
+]
+
+_MUMU_MANAGER_RELPATH = r'shell\MuMuManager.exe'
+_NEMU_API_RELPATH = r'shell\sdk\external_renderer_ipc\windows\x86_64\nemu_bridge.dll'
+
+
+# ---------------------------------------------------------------------------
+# Path detection
+# ---------------------------------------------------------------------------
+
+def _read_registry_path(hive: int, subkey: str, value: str) -> str | None:
+    try:
+        with winreg.OpenKey(hive, subkey, access=winreg.KEY_READ) as k:
+            val, _ = winreg.QueryValueEx(k, value)
+            return str(val) if val else None
+    except (OSError, FileNotFoundError):
+        return None
+
+
+def _scan_drives_for_mumu() -> str | None:
+    """Scan all available drives for MuMuPlayer or MuMuPlayerGlobal directories."""
+    target_dirs = ['MuMuPlayer12', 'MuMuPlayerGlobal']
+    # Get all available drive letters on Windows
+    drives: list[str] = []
+    bitmask = ctypes.windll.kernel32.GetLogicalDrives()  # type: ignore[attr-defined]
+    for i in range(26):
+        if bitmask & (1 << i):
+            drives.append(chr(65 + i) + ':\\')
+
+    search_roots = [
+        os.path.join(d, 'Program Files', 'Netease') for d in drives
+    ] + [
+        os.path.join(d, 'Program Files (x86)', 'Netease') for d in drives
+    ]
+
+    for root in search_roots:
+        if not os.path.isdir(root):
+            continue
+        for name in target_dirs:
+            candidate = os.path.join(root, name)
+            manager = os.path.join(candidate, _MUMU_MANAGER_RELPATH)
+            if os.path.isfile(manager):
+                logger.info('Found MuMu via disk scan: %s', candidate)
+                return candidate
+    return None
+
+
+def find_mumu_path() -> str | None:
+    """Return MuMu Player installation directory, or None if not found."""
+    # 1. Environment variable override
+    env_path = os.environ.get('MUMU_PATH', '').strip()
+    if env_path and os.path.isdir(env_path):
+        return env_path
+
+    # 2-5. Registry candidates
+    for hive, subkey, value in _REGISTRY_CANDIDATES:
+        path = _read_registry_path(hive, subkey, value)
+        if path and os.path.isdir(path):
+            return path
+
+    # 6. Disk scan fallback
+    return _scan_drives_for_mumu()
+
+
+# ---------------------------------------------------------------------------
+# Host configuration
+# ---------------------------------------------------------------------------
+
+class MuMu12HostConfig:
+    """Configuration for MuMu 12 nemu_ipc connection."""
+
+    def __init__(self, install_path: str | None = None) -> None:
+        self.install_path: str | None = install_path or find_mumu_path()
+
+    def nemu_api_path(self) -> str | None:
+        if self.install_path is None:
+            return None
+        p = os.path.join(self.install_path, _NEMU_API_RELPATH)
+        return p if os.path.isfile(p) else None
+
+    def manager_path(self) -> str | None:
+        if self.install_path is None:
+            return None
+        p = os.path.join(self.install_path, _MUMU_MANAGER_RELPATH)
+        return p if os.path.isfile(p) else None
+
+
+# ---------------------------------------------------------------------------
+# Instance model (compatible with kotonebot.client.host.protocol.Instance)
+# ---------------------------------------------------------------------------
+
+class MuMuInstance:
+    """Represents one MuMu emulator instance."""
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        install_path: str,
+        host_cls: type,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self._install_path = install_path
+        self._host_cls = host_cls
+
+    # ---- lifecycle -------------------------------------------------------
+
+    def running(self) -> bool:
+        manager = os.path.join(self._install_path, _MUMU_MANAGER_RELPATH)
+        try:
+            result = subprocess.run(
+                [manager, 'isvmrunning', '-v', self.id],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def start(self) -> None:
+        manager = os.path.join(self._install_path, _MUMU_MANAGER_RELPATH)
+        subprocess.Popen([manager, 'startvm', '-v', self.id])
+
+    def stop(self) -> None:
+        manager = os.path.join(self._install_path, _MUMU_MANAGER_RELPATH)
+        subprocess.run([manager, 'stopvm', '-v', self.id], timeout=30)
+
+    def wait_available(self, timeout: float = 180) -> None:
+        import time
+        from kotonebot.util import Countdown
+        cd = Countdown(timeout)
+        while not cd.expired():
+            if self.running():
+                time.sleep(3)
+                return
+            time.sleep(2)
+        raise TimeoutError(f'MuMu instance {self.id} did not start within {timeout}s')
+
+    def refresh(self) -> None:
+        pass
+
+    def create_device(self, impl: str, config: Any) -> Any:
+        """Create a kotonebot Device using the given impl and config."""
+        from kotonebot.client import Device
+        from kotonebot.client.host.protocol import AdbHostConfig
+
+        if impl == 'nemu_ipc':
+            # Delegate to the parent host class's nemu_ipc factory
+            return self._host_cls._create_nemu_device(self, config)
+        elif impl in ('adb', 'scrcpy', 'uiautomator2'):
+            adb_cfg = config if isinstance(config, AdbHostConfig) else AdbHostConfig()
+            return self._host_cls._create_adb_device(self, impl, adb_cfg)
+        else:
+            raise ValueError(f'Unknown impl: {impl}')
+
+    # ---- ADB helpers (used by create_device 'adb' path) -----------------
+
+    @property
+    def adb_serial(self) -> str | None:
+        return None  # auto-detect via MuMu SDK
+
+    def __repr__(self) -> str:
+        return f'MuMuInstance(id={self.id!r}, name={self.name!r})'
+
+
+# ---------------------------------------------------------------------------
+# Host base class
+# ---------------------------------------------------------------------------
+
+class _MuMuHostBase:
+    _emulator_type: ClassVar[str] = 'mumu'  # subclasses override
+
+    @classmethod
+    def _get_install_path(cls) -> str:
+        path = find_mumu_path()
+        if path is None:
+            raise RuntimeError(
+                'MuMu Player not found. Set MUMU_PATH environment variable or install MuMu Player.'
+            )
+        return path
+
+    @classmethod
+    def _run_manager(cls, install_path: str, *args: str) -> str:
+        manager = os.path.join(install_path, _MUMU_MANAGER_RELPATH)
+        if not os.path.isfile(manager):
+            raise FileNotFoundError(f'MuMuManager not found: {manager}')
+        result = subprocess.run(
+            [manager, *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout
+
+    @classmethod
+    def list(cls) -> list[MuMuInstance]:
+        try:
+            path = cls._get_install_path()
+            output = cls._run_manager(path, 'vms', 'list')
+            return cls._parse_instance_list(output, path)
+        except Exception as exc:
+            logger.warning('Failed to list MuMu instances: %s', exc)
+            return []
+
+    @classmethod
+    def _parse_instance_list(cls, output: str, install_path: str) -> list[MuMuInstance]:
+        """Parse JSON or line-based output from MuMuManager vms list."""
+        instances: list[MuMuInstance] = []
+        try:
+            import json
+            data = json.loads(output)
+            for item in data:
+                idx = str(item.get('index', item.get('id', '')))
+                name = str(item.get('name', f'MuMu-{idx}'))
+                instances.append(MuMuInstance(idx, name, install_path, cls))
+        except Exception:
+            # Fallback: line-based format "0 MuMuPlayer12-0"
+            for line in output.splitlines():
+                parts = line.strip().split(None, 1)
+                if len(parts) >= 1 and parts[0].isdigit():
+                    idx = parts[0]
+                    name = parts[1] if len(parts) > 1 else f'MuMu-{idx}'
+                    instances.append(MuMuInstance(idx, name, install_path, cls))
+        return instances
+
+    @classmethod
+    def query(cls, id: str) -> MuMuInstance | None:
+        for inst in cls.list():
+            if str(inst.id) == str(id):
+                return inst
+        return None
+
+    @classmethod
+    def check_app_keptlive(cls, id: str) -> bool:
+        """Check if MuMu's background app keep-alive is enabled (interferes with automation)."""
+        try:
+            path = cls._get_install_path()
+            output = cls._run_manager(path, 'vm', 'settings', '-v', str(id))
+            return '"keepAlive":true' in output or '"keep_alive":true' in output
+        except Exception:
+            return False
+
+    # ---- device creation helpers (called from MuMuInstance.create_device) --
+
+    @classmethod
+    def _create_nemu_device(cls, instance: MuMuInstance, config: Any) -> Any:
+        """Create a device via nemu_ipc (MuMu's native IPC)."""
+        from kotonebot.client.host.mumu12_host import MuMu12HostConfig as _OrigConfig
+        # Try to use the original kotonebot nemu_ipc implementation if available
+        try:
+            # kotonebot's nemu_ipc factory expects an instance with .id
+            from kotonebot.client.implements.nemu_ipc import NemuIPCDevice
+            ipc_cfg = config if isinstance(config, _OrigConfig) else _OrigConfig(
+                install_path=instance._install_path
+            )
+            return NemuIPCDevice.create(
+                vm_index=int(instance.id),
+                install_path=instance._install_path,
+            )
+        except Exception as exc:
+            raise RuntimeError(f'nemu_ipc device creation failed: {exc}') from exc
+
+    @classmethod
+    def _create_adb_device(cls, instance: MuMuInstance, impl: str, config: Any) -> Any:
+        from kotonebot.client import Device
+        # Resolve ADB serial via MuMu Manager
+        try:
+            path = cls._get_install_path()
+            output = cls._run_manager(path, 'adb', 'conn', '-v', str(instance.id))
+            serial = output.strip().split()[-1] if output.strip() else None
+        except Exception:
+            serial = None
+
+        from kotonebot.client.host.adb_common import AdbRecipes, CommonAdbCreateDeviceMixin
+        from kotonebot.client.host.protocol import AdbHostConfig
+
+        adb_cfg = config if isinstance(config, AdbHostConfig) else AdbHostConfig()
+
+        class _TmpInst(CommonAdbCreateDeviceMixin):
+            def __init__(self) -> None:
+                super().__init__(
+                    id=instance.id,
+                    name=instance.name,
+                    adb_ip='127.0.0.1',
+                    adb_port=None,
+                    adb_name=None,
+                    adb_serial=serial,
+                )
+
+        return _TmpInst().create_device(impl, adb_cfg, connect=False, disconnect=False)
+
+
+# ---------------------------------------------------------------------------
+# Public host classes
+# ---------------------------------------------------------------------------
+
+class Mumu12Host(_MuMuHostBase):
+    """MuMu Player 12 host (CN edition)."""
+    _emulator_type = 'mumu'
+
+
+class Mumu12V5Host(_MuMuHostBase):
+    """MuMu Player 12 v5 SDK host."""
+    _emulator_type = 'mumu_v5'
+
+
+__all__ = [
+    'MuMu12HostConfig',
+    'MuMuInstance',
+    'Mumu12Host',
+    'Mumu12V5Host',
+    'find_mumu_path',
+]


### PR DESCRIPTION
### 新增
- **Discord Webhook通知** — Settings → 通知 → 開啟「推送通知」→ 選「Discord Webhook」→ 貼入 URL

### 修復
- **MuMu Global 偵測** — V5Host 現在也會查 MuMuPlayerGlobal 的 registry key(不會再判定找不到)
- **Lawnchair 偵測** — app.lawnchair 現在能被正確識別為 home launcher，不再卡在 "Waiting for launcher"