### PR TITLE
docs: add initial Global / EN server notes / 添加国际服初步兼容性记录

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,110 @@
+# Ichika's Auto Assistant 一歌小助手
+
+<small>Related projects: [
+    <a href="https://github.com/XcantloadX/kotones-auto-assistant">Kotone's Auto Assistant</a>,
+    <a href="https://github.com/XcantloadX/kotonebot">kotonebot automation framework</a>
+]
+</small>
+
+<center><img src="./assets/icon_round.png" width="128"/></center>
+
+
+Ichika's Auto Assistant, abbreviated as IAA, is an automation script for daily tasks in *Project SEKAI: Colorful Stage!*. It is built on the kotonebot automation framework and uses OpenCV to detect on-screen images for automation.
+
+> [!IMPORTANT]  
+> Ichika's Auto Assistant is **only intended for daily task automation**. It cannot and will not support any cheat-like functionality, such as automated shows for ranking purposes.
+
+## Roadmap
+
+* Reward collection
+    - [x] Claim gifts from the gift box
+    - [ ] Claim mission rewards, including pass rewards
+* Watch ads / CM
+    - [x] Ads at Scramble Crossing
+    - [ ] Ads in the music shop
+* Auto live
+    - [x] Basic functionality
+    - [x] Farm live count / leader count (`LIVE FINISH`)
+    - [x] Farm `CLEAR` count, such as completing 50 shows
+    - [x] Farm song-clear count, such as clearing 10 different songs
+* Multi-server support
+  - [x] Taiwan server
+  - [ ] Mainland China server
+  - [ ] International / Global server
+* Auto story
+    - [x] Auto main story
+    - [x] Auto current event story
+* Area conversations
+* Virtual live
+* MySekai auto collection
+* Native mobile support
+
+## Disclaimer
+
+By downloading and using Ichika's Auto Assistant, you confirm that you have read and agree to the following disclaimer:
+
+1. This project is **not cheat software** and does not modify any game content.
+2. You are solely responsible for any risks caused by using this project, including but not limited to **account bans**.
+3. This project is not affiliated with CraftEgg, Crypton Future Media, Colorful Palette, SEGA, ByteDance, or Ariel Network.
+4. This project is provided free of charge and is **not allowed to be used for commercial purposes**, such as selling packaged builds of this project.
+5. All game assets used by this project, if any, come from SekaiViewer.
+
+By continuing to download, install, or use this project, you confirm that you have fully read, understood, and agreed to accept all of the above risks and terms. If you do not agree, stop using this project immediately and delete all related files.
+
+## CLI Quick Start
+
+In addition to the GUI, IAA can also be used from the command line.
+
+```bash
+# Show help
+iaa-cli.exe --help
+# List available tasks
+iaa-cli.exe list tasks
+# Run regular tasks according to the current configuration
+iaa-cli.exe run
+# Explicitly run one or more tasks
+iaa-cli.exe invoke start_game solo_live
+# Run a single task
+iaa-cli.exe invoke main_story
+# Run auto live with arguments
+iaa-cli.exe invoke auto_live --count-mode specify --count 10 --loop-mode list --auto-mode game_auto
+```
+
+## Development
+
+Install `just` first, then run:
+
+```powershell
+# Set up the Python environment
+just setup
+# Build resource files
+just res
+
+# Start the GUI
+uv run launch_desktop.py
+# Or start "main (GUI)" from VS Code
+
+# Start the CLI
+python -m iaa.main ... # See the CLI Quick Start section above for arguments
+```
+
+For now, later documentation can refer to Kotone's Auto Assistant development documentation.
+
+### Packaging
+
+After running `just build`, the `dist_app` directory will contain both:
+
+* `iaa.exe`: GUI entry point
+* `iaa-cli.exe`: CLI entry point
+
+### Release
+
+See [doc/LOCAL_RELEASE.md](./doc/LOCAL_RELEASE.md).
+
+### Contributing
+
+TODO
+
+## License
+
+Ichika's Auto Assistant is open-sourced under the GPLv3 license.

--- a/doc/global/README_en.md
+++ b/doc/global/README_en.md
@@ -1,0 +1,100 @@
+# Global / EN Server Support Notes
+
+This folder tracks Global / EN server compatibility work for Ichika's Auto
+Assistant (IAA).
+
+IAA is a daily-automation tool for Project Sekai built on kotonebot and screen
+recognition. These notes follow the upstream project's safety boundary: Global
+support work should focus on ordinary daily automation and must not introduce
+cheat-like behavior, ranking automation, account modification, or bypasses.
+
+## Current conclusion
+
+Global / EN is **not supported as a stock configuration yet**.
+
+The current evidence shows that Global support is possible, but it still needs a
+proper implementation path. Several local candidate patches worked in one test
+environment, but those results must not be treated as official support until
+they are reviewed, merged, and reproduced by maintainers.
+
+## Key blockers
+
+| Area | Current finding | Impact |
+| --- | --- | --- |
+| Server selection | The GUI currently exposes JP, TW, and CN, but not Global / EN. | A valid Global profile cannot be selected. |
+| Package mapping | The tested Global package is `com.sega.ColorfulStage.en`; the JP profile targets `com.sega.pjsekai`. | Stock IAA cannot launch the Global app through a normal server setting. |
+| Resource variant | The useful Global resource variant is `en`; inherited JP resources are only a baseline. | Global needs tested EN resources for English text and changed navigation labels. |
+| Home navigation | JP `Hud.ButtonLive` did not match the Global `SHOW` button. | Tasks that enter shows need an EN override or a non-text detector. |
+| Startup flow | `start_game` reached a blank white loading frame and fell into repeated fallback clicks in the local probe. | Startup recovery needs safer unknown/loading-state handling before Global is considered supported. |
+| Capture backend | In the recorded environment, Nemu IPC returned all-white Global frames; ADB and Scrcpy captured usable frames. | Capture backend compatibility must be documented and retested on more setups. |
+| CM / ads | Global ad providers vary; English `Watch Ad` and reward text require EN recognition. | CM support should remain partial/unknown until provider exits, redirects, and reward states are retested. |
+
+## What worked in local candidate testing
+
+The following results are useful evidence, but they are **not stock support**.
+They used temporary local package mapping, generated EN resources, or candidate
+task changes.
+
+| Flow | Candidate result | Still missing |
+| --- | --- | --- |
+| `solo_live` | One bounded list-mode game-Auto show completed and returned home. | Other modes, script Auto, auto-unit setup, insufficient energy, recovery items, and changed result flows. |
+| `auto_live` | One bounded list-mode game-Auto run completed and returned home. | Broader modes and scheduled regular task behavior. |
+| `mission_rewards` | One no-reward run and one fresh claim completed; English overlay was dismissed. | Different tab counts, reward sets, pass states, and future UI changes. |
+| `gift` | One fresh two-item claim completed; English confirmation dialog was dismissed. | Other gift types and future dialog variations. |
+| startup pop-ups | Observed login bonus, monthly subscription, and News states were handled. | Consent, maintenance, update, and other promotional dialogs. |
+| `challenge_live` | One Minori Auto Play challenge show completed with temporary English templates. | Stock task still stalls on English text; weekly reward flow untested. |
+| `area_convos` | One area was cleared with temporary English story-skip resources. | Stock skip flow is broken; task can report completion even when unread badges remain; multi-area traversal is incomplete. |
+| `cm` | One bounded reward was claimed; one ambiguous provider return stopped safely. | Provider-independent handling is not verified; empty-frame provider transition needs retesting. |
+| `activity_story` | World Link route and no-unread branch were exercised with generated EN resources. | Unread-story chain from home to completion remains unverified. |
+| `event_shop` | World Link shop scan completed with no purchase because targets were absent. | Ordinary event layout, purchase confirmation, and insufficient-currency paths. |
+
+## Status language
+
+Use these terms consistently:
+
+| Status | Meaning |
+| --- | --- |
+| Verified working | Reproduced successfully in a documented Global test environment. Only use this when the exact implementation under review was tested. |
+| Known broken | Reproduced failure with enough evidence to investigate. |
+| Untested | No Global test result has been recorded. |
+| Unknown | Evidence exists, but it is incomplete, conflicting, local-only, or no longer current. |
+| Candidate verified | A local or proposed patch worked in a bounded Global test, but stock support is not confirmed. |
+
+## Recommended implementation order
+
+Keep Global work reviewable. Small PRs are much safer than one large "Global
+support" PR.
+
+1. Add a selectable Global / EN server profile and package mapping.
+2. Add the `en` resource variant without claiming broad support.
+3. Verify capture backend behavior and document known backend limitations.
+4. Add the minimum EN resources needed for home recognition and safe startup.
+5. Add low-risk reward flows first: Gifts and Missions.
+6. Add bounded show flows: `solo_live` / `auto_live` with explicit counts.
+7. Add stories, area conversations, and event shop only after bounded smoke
+   tests are reproducible.
+8. Leave CM / advertisement support for last because provider behavior varies
+   by region, account, time, and ad network.
+
+## Files in this folder
+
+| File | Purpose |
+| --- | --- |
+| [`STATUS_MATRIX.md`](./STATUS_MATRIX.md) | Maintainer-facing stock vs candidate status table. |
+| [`SMOKE_TEST_CHECKLIST.md`](./SMOKE_TEST_CHECKLIST.md) | Reusable Global test checklist for future maintainers. |
+| [`TEST_LOG_2026-06-14_to_2026-06-16.md`](./TEST_LOG_2026-06-14_to_2026-06-16.md) | Condensed record of the first Global compatibility investigation. |
+| [`REPORT_TEMPLATE.md`](./REPORT_TEMPLATE.md) | Template for future Global test reports or issues. |
+
+## Evidence and privacy rules
+
+Do not attach raw screenshots or logs without review.
+
+- Blur player names, user IDs, transfer/account screens, and any other private
+  account identifiers.
+- Do not publish full logs if they include local paths, account state, device
+  identifiers, or screenshots with private information.
+- Record the IAA commit, game version, emulator, backend, resolution, and time
+  zone with every test.
+- Mark inconclusive results as `Unknown`, not `Verified working`.
+- Do not claim Global support from inherited JP resources. A reused template is
+  only valid after it is tested against representative Global frames.

--- a/doc/global/REPORT_TEMPLATE.md
+++ b/doc/global/REPORT_TEMPLATE.md
@@ -1,0 +1,83 @@
+# Global / EN Test Report Template
+
+Use this template for new Global compatibility reports.
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Date / time zone | |
+| Tester | |
+| IAA commit / branch | |
+| Global game version | |
+| Emulator / device | |
+| Capture backend | |
+| Task / feature | |
+| Result | `Verified working` / `Known broken` / `Unknown` / `Untested` / `Candidate verified` |
+| Stock or candidate patch? | |
+| Account state changed? | Yes / No |
+| Evidence location | |
+
+## What was tested
+
+Describe the exact task, start page, options, and expected outcome.
+
+```text
+Example:
+Started from recognized Global home. Ran solo_live with list mode, count 1,
+game Auto, Bonus Energy multiplier 1, and auto-unit setup disabled.
+```
+
+## Environment
+
+| Detail | Value |
+| --- | --- |
+| Host OS | |
+| Emulator / device | |
+| Android package | `com.sega.ColorfulStage.en` |
+| Game language | English |
+| IAA UI language | |
+| Screen resolution | |
+| Display scaling / DPI | |
+| Backend | |
+| Network/ad-provider notes | |
+| Local patches or overrides | |
+
+## Steps
+
+1.
+2.
+3.
+
+## Expected result
+
+-
+
+## Actual result
+
+-
+
+## Recognition results
+
+| Resource / detector | Result | Notes |
+| --- | --- | --- |
+| | | |
+
+## Logs and screenshots
+
+Attach only sanitized evidence.
+
+- [ ] Player name removed.
+- [ ] User ID removed.
+- [ ] Transfer/account information removed.
+- [ ] Local paths or secrets removed from logs.
+- [ ] Screenshots cropped to the relevant UI only.
+
+## Follow-up
+
+| Item | Type | Owner | Notes |
+| --- | --- | --- | --- |
+| | Resource | | |
+| | Code | | |
+| | Test | | |
+| | Documentation | | |

--- a/doc/global/SMOKE_TEST_CHECKLIST.md
+++ b/doc/global/SMOKE_TEST_CHECKLIST.md
@@ -1,0 +1,240 @@
+# Global / EN Smoke Test Checklist
+
+Use this checklist for future Global / EN compatibility runs.
+
+The goal is not to prove everything works in one run. The goal is to collect
+small, reproducible, low-risk evidence without hiding failures.
+
+## Rules
+
+- Test one feature at a time.
+- Start from a known page.
+- Use bounded runs whenever possible.
+- Stop immediately after an unexpected action, page transition, or repeated
+  click loop.
+- Preserve evidence before retrying.
+- Do not run broad scheduled automation until individual tasks are understood.
+- Do not claim support from local-only patches unless the implementation under
+  review includes those changes.
+- Do not use automation for ranking, cheating, account modification, or bypasses.
+
+## Environment
+
+Record this table for every session.
+
+| Detail | Value |
+| --- | --- |
+| IAA commit / version | |
+| Branch / PR | |
+| Global game version | |
+| Test date and time zone | |
+| Tester | |
+| Host OS | |
+| Emulator / device | |
+| Game package | `com.sega.ColorfulStage.en` |
+| Game language | English |
+| IAA UI language | |
+| Capture backend | |
+| Screen resolution | |
+| Display scaling / DPI | |
+| Account state relevant to test | |
+| Network/ad-provider notes | |
+| Local patches or overrides used | |
+
+## Preparation
+
+- [ ] Confirm the test branch and commit.
+- [ ] Confirm whether Global / EN is a real selectable server option.
+- [ ] Confirm the target package is `com.sega.ColorfulStage.en`.
+- [ ] Confirm the resource variant being used.
+- [ ] Confirm the capture backend before task execution.
+- [ ] Disable or avoid unrelated tasks.
+- [ ] Prepare sanitized screenshot/log output location.
+- [ ] Record the starting game page.
+- [ ] Record whether the account has pending gifts, missions, ads, challenge attempt, stories, or event-shop targets.
+
+## Connection and capture
+
+- [ ] Launch the IAA GUI.
+- [ ] Open the server selector and record available server choices.
+- [ ] Launch or connect to MuMu / emulator / device.
+- [ ] Confirm foreground package before task execution.
+- [ ] Capture one title or home frame through the selected backend.
+- [ ] If testing MuMu Player Global, record whether discovery uses the expected registry key.
+- [ ] Compare ADB or Scrcpy if Nemu IPC returns blank/white/empty frames.
+- [ ] Do not validate templates using a backend that does not expose the rendered Global frame.
+
+## Startup and home recognition
+
+- [ ] Launch Global from a stopped app state.
+- [ ] Record loading screens and pop-ups.
+- [ ] Confirm whether the startup flow reaches title, News, or home.
+- [ ] Confirm that unexpected pages do not trigger blind repeated clicks.
+- [ ] Verify home recognition from an unobstructed Global home / area page.
+- [ ] Verify the Global `SHOW` navigation control.
+- [ ] Verify back/home recovery from at least one safe non-home page.
+
+## Resource checks
+
+Before implementing an EN resource, test whether the JP resource works on a
+representative Global frame.
+
+| Resource | Result | Notes |
+| --- | --- | --- |
+| `Login.IconNotification` | | |
+| `Daily.ButtonGift` | | |
+| `Daily.ButtonMission` | | |
+| `Hud.IconCrystal` | | |
+| `Login.ButtonMenu` | | |
+| `Hud.ButtonLive` / Global `SHOW` | | |
+| `Hud.ButtonStory` | | |
+| `Map.ButtonOpenMap` | | |
+| `Map.IconNewAreaConvo` | | |
+| `Scene.Intersection.IconCm` | | |
+| `Cm.ButtonPlayCm` / Global `Watch Ad` | | |
+| `Hud.ButtonClaimAll` / Global `Claim All` | | |
+| Reward/confirmation dialog text | | |
+| Score-rank completion text | | |
+
+Possible results:
+
+- `Matched`
+- `Did not match`
+- `Needs EN template`
+- `Needs non-text detector`
+- `Not applicable`
+- `Untested`
+
+## Gift test
+
+Run only if a pending gift exists or if testing the empty state.
+
+- [ ] Start from recognized home.
+- [ ] Open Gifts.
+- [ ] Confirm the Gift page is loaded before clicking.
+- [ ] If gifts exist, record visible gift types without exposing account info.
+- [ ] Click `Claim All` once.
+- [ ] Confirm whether a persistent English confirmation dialog appears.
+- [ ] Dismiss the dialog with a tested EN resource.
+- [ ] Confirm return home.
+- [ ] Run empty-state path only if safe.
+- [ ] Record final status.
+
+## Mission rewards test
+
+Run only with a known badge state.
+
+- [ ] Start from recognized home.
+- [ ] Open Missions.
+- [ ] Wait for the page to load.
+- [ ] Record tab count and badged indices.
+- [ ] Confirm `Claim All` recognition on the active tab.
+- [ ] Claim only expected badged tabs.
+- [ ] Dismiss each reward overlay before refreshing the sidebar.
+- [ ] Confirm final badge list is empty.
+- [ ] Record final status.
+
+## Solo live / auto live test
+
+Use the smallest bounded run.
+
+- [ ] Start from recognized home.
+- [ ] Use explicit count `1`.
+- [ ] Use a known play mode, preferably game Auto for the first smoke test.
+- [ ] Use a known Bonus Energy multiplier.
+- [ ] Disable auto-unit setup unless that is the test target.
+- [ ] Confirm Show entry through Global `SHOW`.
+- [ ] Confirm song selection.
+- [ ] Confirm unit selection.
+- [ ] Confirm Bonus Energy dialog handling.
+- [ ] Confirm Auto Play settings.
+- [ ] Watch for the optional Note Speed dialog.
+- [ ] Confirm show start.
+- [ ] Confirm score-rank / completion detection.
+- [ ] Confirm result settlement.
+- [ ] Confirm return home.
+- [ ] Record energy before/after if relevant.
+
+## Challenge Live test
+
+Only run when a daily attempt is naturally available.
+
+- [ ] Confirm daily indicator before the run.
+- [ ] Record selected character.
+- [ ] Confirm character-selection prompt recognition.
+- [ ] Confirm group and character resources.
+- [ ] Use Auto Play if available and appropriate.
+- [ ] Confirm score-rank / completion detection.
+- [ ] Confirm return home.
+- [ ] Confirm daily indicator is absent after the run.
+- [ ] If day 7 weekly reward appears, record the flow separately.
+
+## Area conversations test
+
+This changes account state by marking conversations read.
+
+- [ ] Start in a known area.
+- [ ] Record whether unread badges are visible.
+- [ ] Confirm map entry if testing area traversal.
+- [ ] Confirm `NEW!` marker recognition.
+- [ ] Enter only the intended area.
+- [ ] Confirm story-menu recognition.
+- [ ] Confirm English `Skip` and `Skip the story?` resources.
+- [ ] After task completion, perform an independent full sweep.
+- [ ] Confirm the map no longer shows `NEW!` for the tested area.
+- [ ] Do not trust a single `cleared` log line without visual verification.
+
+## Current event story test
+
+This changes story read state and may collect rewards.
+
+- [ ] Record event type.
+- [ ] Record whether unread story episodes are available.
+- [ ] Confirm event-story entry.
+- [ ] Confirm voice-data dialog handling.
+- [ ] Confirm story menu and skip resources.
+- [ ] Confirm next-episode handling if applicable.
+- [ ] Confirm final return to episode list.
+- [ ] Separately test the no-unread branch.
+
+## Event shop test
+
+Avoid purchases unless the test target is controlled and expected.
+
+- [ ] Record event type: ordinary, World Link, or other.
+- [ ] Confirm event-shop entry resource.
+- [ ] Confirm inventory layout.
+- [ ] Confirm configured purchase target.
+- [ ] Confirm currency availability.
+- [ ] If no target is present, verify safe no-purchase exit.
+- [ ] If purchase is tested, record confirmation and final currency state.
+- [ ] Test insufficient-currency behavior separately.
+
+## CM / advertisement test
+
+CM tests consume daily ad opportunities and may leave the game.
+
+- [ ] Start from Scramble Crossing or the intended CM entry page.
+- [ ] Confirm `Watch Ads` bubble recognition.
+- [ ] Open the ad-selection page.
+- [ ] Record visible reward cards and remaining count.
+- [ ] Confirm English `Watch Ad` button recognition.
+- [ ] Run only one ad for the first smoke test.
+- [ ] Record provider path: in-game, Google Play, Meta/Facebook, browser, or other.
+- [ ] Record whether the provider returns automatically.
+- [ ] Record whether Home/relaunch recovery was needed.
+- [ ] Confirm reward overlay or failure state.
+- [ ] Confirm selection-page ambiguous return stops safely.
+- [ ] Confirm no indefinite polling.
+- [ ] Do not mark full CM support until multiple providers are tested uninterrupted.
+
+## Evidence review
+
+- [ ] Redact player username.
+- [ ] Redact user ID.
+- [ ] Redact transfer/account screens.
+- [ ] Remove local paths or secrets from logs.
+- [ ] Include timestamp, task name, branch, and commit.
+- [ ] Attach only the smallest useful screenshot set.
+- [ ] Mark inconclusive results as `Unknown`.
+- [ ] Clearly label local-only workarounds.

--- a/doc/global/STATUS_MATRIX.md
+++ b/doc/global/STATUS_MATRIX.md
@@ -1,0 +1,104 @@
+# Global / EN Status Matrix
+
+This matrix separates **stock upstream behavior** from **local candidate patch
+behavior**. Do not collapse those two columns. A flow that works with local
+patches is still not stock Global support.
+
+## Test environment used for the first investigation
+
+| Detail | Value |
+| --- | --- |
+| IAA version / commit | `26.05b2` / `4478949` |
+| Global game version | `5.3.5.Luna` |
+| Test dates | 2026-06-14 to 2026-06-16 |
+| Host OS | Windows 10 Home 64-bit, build 19045 |
+| Emulator | MuMu Player Global `5.30.2.3616` / MuMu 12 v5, instance `0` |
+| Game package | `com.sega.ColorfulStage.en` |
+| Game language | English |
+| IAA UI language | Chinese |
+| Capture backends tested | Nemu IPC, ADB, Scrcpy |
+| Working capture backends in this environment | ADB and Scrcpy |
+| Problematic backend in this environment | Nemu IPC returned all-white Global frames |
+| Important caveat | Temporary local workarounds were used for some probes. They are not stock support. |
+
+## Configuration and device layer
+
+| Area | Stock Global status | Candidate / local finding | Evidence / blocker |
+| --- | --- | --- | --- |
+| Desktop GUI launch | Works | N/A | GUI opened on Windows. UI is currently Chinese. |
+| Global / EN server option | Known broken | Not implemented | Server selector showed JP, TW, CN only. |
+| Global package mapping | Known broken | Local override launched Global | Stock JP profile targets `com.sega.pjsekai`; Global package is `com.sega.ColorfulStage.en`. |
+| MuMu Player Global discovery | Known broken in tested setup | Local `.venv` registry fallback worked | MuMu Player Global used `MuMuPlayerGlobal` registry key; stock kotonebot checked `MuMuPlayer`. |
+| MuMu startup | Works after discovery workaround | N/A | With **Check and start** enabled, runtime ADB port was assigned. |
+| Nemu IPC capture | Known broken in tested setup | Not fixed | Returned all-white 960 x 540 frames while Global Unity activity was focused. |
+| ADB capture | Works in tested setup | N/A | Captured visible Global loading/title frames at 960 x 540. |
+| Scrcpy capture | Works in tested setup | N/A | Captured visible Global title screen at 960 x 544, scaled for recognition. |
+| `start_game` | Known broken | Local guard prevented blind clicks | Global launched, then blank white loading frame caused `go_home()` fallback clicks at `(1, 367)`. |
+
+## Resource compatibility
+
+| Resource / UI area | Stock JP resource on Global | Candidate / EN status | Notes |
+| --- | --- | --- | --- |
+| `Login.IconNotification` | Matched | Can likely reuse after retest | Matched Global News dialog. |
+| `Daily.ButtonGift` | Matched | Can likely reuse after retest | Matched unobstructed Global home / area frame. |
+| `Daily.ButtonMission` | Matched | Can likely reuse after retest | Matched unobstructed Global home / area frame. |
+| `Hud.IconCrystal` | Matched | Can likely reuse after retest | Matched unobstructed Global home / area frame. |
+| `Login.ButtonMenu` | Matched | Can likely reuse after retest | Matched unobstructed Global home / area frame. |
+| `Hud.ButtonLive` | Did not match | EN `SHOW` resource needed | Global bottom navigation says `SHOW`, not `LIVE`. |
+| `Hud.ButtonStory` | Did not match | EN or non-text detector needed | Failed on recorded Global home frame. |
+| `Map.IconNewAreaConvo` | Matched | Can likely reuse after retest | Matched visible Global `NEW!` badges. |
+| `Scene.Intersection.BuildingLogo` | Matched | Can likely reuse after retest | Matched Global Scramble Crossing frame. |
+| `Scene.Intersection.IconCm` | Matched | Can likely reuse after retest | Matched Global `Watch Ads` bubble across shifted viewports. |
+| `Cm.ButtonPlayCm` | Did not match | EN `Watch Ad` resource needed | English ad-selection buttons differ. |
+| `Cm.TextAwardClaimed` | Did not match | EN reward text resource needed | Global overlay uses English `Claimed rewards.` text. |
+| CM ad close / skip | Did not match tested provider | Unknown | Provider redirected to Google Play; ad controls vary. |
+| `Hud.ButtonClaimAll` | Did not match Missions | EN `Claim All` resource needed | JP template scored below threshold on Global Missions. |
+| Gift confirmation dialog | Not handled by baseline task | EN `CommonDialog` resources worked | Global uses persistent `Claimed the following items.` dialog. |
+| Challenge character prompt | Did not match | EN text resource needed | Global prompt is `Please select a character.` |
+| Score-rank completion | Did not match threshold | EN `SCORE RANK` resource needed | Required for post-show wait in tested flows. |
+
+## Automation task status
+
+| Task / flow | Stock Global status | Candidate / local status | Notes |
+| --- | --- | --- | --- |
+| `gift` | Known broken | Candidate verified for one fresh two-item claim | Stock task does not dismiss Global confirmation dialog after successful claim. |
+| `mission_rewards` | Known broken | Candidate verified for no-reward and one fresh claim path | Stock task cannot recognize English `Claim All` and does not dismiss persistent reward overlay. |
+| `solo_live` | Blocked / unknown | Candidate verified for one bounded list-mode game-Auto show | Requires Global package mapping and EN resource variant. Other modes untested. |
+| `auto_live` | Blocked / unknown | Candidate verified for one bounded list-mode game-Auto run | One explicit count run completed and returned home. Scheduled behavior untested. |
+| `challenge_live` | Known broken | Partial local compatibility | Completed one Minori Auto Play run only with temporary English character-prompt and score-rank resources. Weekly reward untested. |
+| `area_convos` | Known broken / unknown | Partial local compatibility | Existing JP map/story menu resources matched, but English skip flow needs EN resources. Current task can falsely report completion. |
+| `cm` | Known broken / unknown | Partial candidate evidence | Baseline cannot recognize English `Watch Ad`; candidate handled one reward and one ambiguous return. Provider coverage incomplete. |
+| `activity_story` | Unknown | Partial candidate evidence | World Link route and no-unread branch worked. Unread story chain from home remains unverified. |
+| `event_shop` | Unknown | Partial candidate evidence | World Link shop scan worked with no purchase. Ordinary event inventory and purchase paths unverified. |
+| `main_story` | Untested | Not recommended as smoke test yet | JP `Hud.ButtonStory` failed on current Global home frame. |
+| Scheduled regular run | Untested | Not recommended yet | Test individual flows first. |
+| CLI task discovery | Works | N/A | Task listing is side-effect free. |
+| CLI task invocation | Untested for stock Global | Use bounded local probes only | Stock tasks perform navigation/account actions. |
+| GUI task launch | Untested for stock Global | Not recommended yet | Global profile is not selectable. |
+
+## Safe next tests
+
+Prefer low-risk, bounded, reproducible tests:
+
+1. Verify Global / EN profile selection after package mapping is implemented.
+2. Retest ADB and Scrcpy capture on a clean Global title/home frame.
+3. Confirm home recognition using the EN `SHOW` resource.
+4. Run `gift` with a small pending gift set.
+5. Run `mission_rewards` with one known pending badge.
+6. Run `solo_live` or `auto_live` only with explicit count `1` and a known start page.
+7. Retest Challenge Live only when a daily attempt is naturally available.
+8. Retest stories and event shop only with clear account-state expectations.
+9. Retest CM last because it consumes daily ad opportunities and provider paths vary.
+
+## Do not mark as supported yet
+
+Do not mark the following as fully supported from the current evidence:
+
+- Global / EN as a selectable stock server.
+- Startup from app closed to recognized home.
+- Nemu IPC capture on MuMu Player Global.
+- CM / advertisement provider cleanup.
+- Full scheduled regular-task execution.
+- Story and event shop completion across all event types.
+- Challenge weekly reward selection.
+- Any task that only worked through temporary local `.venv` overrides.

--- a/doc/global/TEST_LOG_2026-06-14_to_2026-06-16.md
+++ b/doc/global/TEST_LOG_2026-06-14_to_2026-06-16.md
@@ -1,0 +1,354 @@
+# Global / EN Test Log: 2026-06-14 to 2026-06-16
+
+This is a condensed maintainer-facing record of the first Global / EN
+compatibility investigation.
+
+It preserves the useful findings from the original raw notes while avoiding a
+large personal lab-notebook format in the main overview.
+
+## Scope
+
+This investigation tested whether IAA could connect to a Global / EN Project
+Sekai installation, capture frames, reuse JP resources, and run selected tasks
+with local or candidate Global changes.
+
+The investigation did **not** prove stock Global support. Global / EN was not a
+selectable server configuration during the test period.
+
+## Environment
+
+| Detail | Value |
+| --- | --- |
+| IAA version / commit | `26.05b2` / `4478949` |
+| Global game version | `5.3.5.Luna` |
+| Test dates | 2026-06-14, 2026-06-15, 2026-06-16 |
+| Time zone | Asia/Singapore |
+| Host OS | Windows 10 Home 64-bit, build 19045 |
+| Emulator | MuMu Player Global `5.30.2.3616` / MuMu 12 v5 |
+| Instance | `0` |
+| Package | `com.sega.ColorfulStage.en` |
+| Game language | English |
+| IAA UI language | Chinese |
+| Capture methods compared | Nemu IPC, ADB, Scrcpy |
+| Resolution observations | MuMu display 960 x 540; Nemu IPC 960 x 540 white frame; ADB 960 x 540 visible frames; Scrcpy 960 x 544 raw visible frame scaled to IAA logical 1280 x 720 |
+| Important local workarounds | Temporary package mapping, temporary registry-key fallback, local EN resource experiments |
+
+## Initial application state
+
+- The IAA desktop GUI opened.
+- The GUI server setting exposed JP, TW, and CN.
+- Global / EN was not selectable.
+- Because there was no Global server profile, valid stock Global task execution
+  was blocked.
+
+## MuMu Player Global discovery
+
+MuMu Player Global registered under:
+
+```text
+HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal
+```
+
+The tested kotonebot version checked the `MuMuPlayer` key for MuMu 12 v5 but did
+not check `MuMuPlayerGlobal`. Stock discovery therefore failed in the tested
+environment.
+
+A temporary local `.venv` fallback was used for investigation only. It allowed
+IAA to discover instance `0`, obtain the runtime ADB endpoint, and create an
+Android device.
+
+With **Check and start** enabled, IAA could start MuMu and wait for an assigned
+runtime ADB port. The observed port was `16384`, but this should not be treated
+as stable.
+
+## Capture backend findings
+
+| Backend | Result |
+| --- | --- |
+| Nemu IPC | Initialized, but returned all-white Global frames while the Global Unity activity was focused. |
+| ADB | Captured visible Global loading and title frames at 960 x 540. |
+| Raw `adb exec-out screencap -p` | Returned valid PNG output during loading. |
+| Scrcpy | Captured visible Global title screen at 960 x 544 after explicit startup. |
+
+Conclusion: ADB and Scrcpy were usable in this environment. Nemu IPC should not
+be used for template validation until the white-frame behavior is understood.
+
+## Package launch finding
+
+The tested Global package was:
+
+```text
+com.sega.ColorfulStage.en
+```
+
+Stock JP configuration targets:
+
+```text
+com.sega.pjsekai
+```
+
+Because the Global package is not mapped to any selectable server, the stock JP
+profile could not launch the Global game. A temporary local package override
+was used only to bring Global to the foreground for investigation.
+
+After local launch, `start_game` reached a blank white loading frame. The
+startup/home recovery logic did not recognize a known home or back template and
+repeatedly clicked `(1, 367)` through the fallback path. This is a real Global
+startup safety blocker.
+
+A local-only guard was later used during testing to disable blind fallback
+clicks for the Global package and raise an explicit timeout instead.
+
+## JP resource reuse probe
+
+Several JP resources matched Global frames, usually when the target was an icon,
+layout feature, or stable marker rather than translated text.
+
+| JP resource | Global result | Notes |
+| --- | --- | --- |
+| `Login.IconNotification` | Matched | News dialog |
+| `Daily.ButtonGift` | Matched | Home / area view |
+| `Daily.ButtonMission` | Matched | Home / area view |
+| `Hud.IconCrystal` | Matched | Home / area view |
+| `Login.ButtonMenu` | Matched | Home / area view |
+| `Map.IconNewAreaConvo` | Matched | `NEW!` area-conversation badge |
+| `Scene.Intersection.BuildingLogo` | Matched | Scramble Crossing |
+| `Scene.Intersection.IconCm` | Matched | `Watch Ads` bubble |
+| `Hud.ButtonLive` | Did not match | Global uses `SHOW` |
+| `Hud.ButtonStory` | Did not match | Failed on recorded Global home frame |
+| `Cm.ButtonPlayCm` | Did not match | Global uses English `Watch Ad` buttons |
+| `Cm.TextAwardClaimed` | Did not match | Global reward overlay uses English text |
+| JP CM ad close / skip resources | Did not match tested provider | Provider behavior varied |
+
+Conclusion: JP inheritance can reduce duplication, but it is not evidence of
+Global support. Each reused template must be tested.
+
+## Startup pop-up and News recovery
+
+Observed startup states:
+
+- login-bonus reward overlay;
+- monthly `COLORFUL+` subscription dialog;
+- News dialog.
+
+Candidate EN resources dismissed the subscription dialog and login-bonus reward
+overlay. The existing JP notification detector recognized News. A bounded
+callback run closed the subscription dialog, closed News, and reached recognized
+home.
+
+This does not cover every possible consent, maintenance, update, provider, or
+promotion page.
+
+## Solo live probe
+
+Initial local probes reached:
+
+- Global home / area page;
+- Show selection;
+- song selection;
+- unit selection;
+- Bonus Energy settings;
+- Auto Play settings;
+- gameplay;
+- completion;
+- result flow;
+- return home.
+
+Observed blockers:
+
+- JP `Hud.ButtonLive` did not match Global `SHOW`.
+- Global song `Select` required an EN template.
+- Bonus Energy dialog text and confirmation required EN templates.
+- Auto Play option text and confirmation required EN templates.
+- Global score/completion text required an EN template.
+- Optional Note Speed dialog blocked the first run until manually disabled.
+
+A later candidate run selected the EN resource variant when the Global package
+was foregrounded. One bounded list-mode game-Auto show completed with Bonus
+Energy multiplier `1` and returned home.
+
+Still untested:
+
+- script Auto;
+- auto-unit setup;
+- insufficient Bonus Energy;
+- recovery item prompts;
+- other song/result states;
+- scheduled run integration.
+
+## Standalone auto live probe
+
+A candidate `auto_live` run used:
+
+- list mode;
+- count `1`;
+- game Auto;
+- Bonus Energy multiplier `1`;
+- automatic unit selection disabled.
+
+Generated EN resources handled Global `SHOW`, song `Select`, Bonus Energy
+dialog text/confirmation, and `SCORE RANK`. Existing JP resources handled Solo
+Show entry, next-song action, Auto Play switch, start-show button, and result
+page advancement.
+
+One uninterrupted candidate run completed and returned home. This is candidate
+evidence only; stock Global configuration remained unavailable.
+
+## Gift probe
+
+Baseline behavior:
+
+- Existing JP `Daily.ButtonGift` opened Global Gifts.
+- EN `Claim All` recognition was needed.
+- After claiming, Global displayed a persistent English confirmation dialog:
+  `Claimed the following items.`
+- Baseline task called `go_home()` without dismissing the dialog and failed.
+
+Candidate behavior:
+
+- EN `CommonDialog` resources recognized and dismissed the confirmation dialog.
+- The empty-state path completed.
+- A later fresh two-item claim completed uninterrupted and returned home.
+
+Additional safety finding:
+
+- Repeated Gift-entry clicks can overlap Global's Random Gift `Watch Ad`
+  control after the page opens. Candidate entry behavior should click once and
+  wait for page recognition.
+
+## Mission rewards probe
+
+Baseline behavior:
+
+- Existing JP `Daily.ButtonMission` opened Global Missions.
+- `SideTabbar` parsed five tabs and detected badges.
+- JP `Hud.ButtonClaimAll` did not match English `Claim All`.
+- Baseline task stalled on the rewards page.
+
+Candidate behavior:
+
+- EN `Claim All` and English reward overlay resources were added.
+- Candidate implementation dismissed the overlay before refreshing the sidebar.
+- One no-reward run completed normally.
+- One fresh claim on badge index `3` completed, dismissed the overlay, verified
+  no remaining badges, and exited normally.
+
+Still untested:
+
+- different tab counts;
+- pass states;
+- different reward combinations;
+- future UI changes.
+
+## Challenge Live probe
+
+A local compatibility run:
+
+- opened Challenge Show;
+- selected MORE MORE JUMP!;
+- selected Minori;
+- completed one Auto Play Challenge Show;
+- processed result pages;
+- returned home;
+- confirmed daily indicator was absent after completion.
+
+Stock blockers:
+
+- JP character-selection prompt did not match Global `Please select a character.`
+- JP score-rank template did not meet threshold on the Global score-rank screen.
+
+Weekly reward selection was not tested.
+
+## Area conversations probe
+
+Existing JP resources that matched:
+
+- map open button;
+- area `NEW!` marker;
+- story menu button.
+
+Stock blockers:
+
+- JP story `Skip` handling repeatedly clicked the icon side of the Global
+  `Skip` control without advancing.
+- JP confirmation resource did not match English `Skip the story?`.
+- One task run reported the area cleared even though an unread badge remained.
+- Current implementation only scans the selected area and does not traverse the
+  full real-world map.
+
+A bounded local probe with EN story-skip resources cleared the remaining visible
+conversation in one area. A final sweep found zero unread badges for that area.
+
+## CM / advertisement probe
+
+Baseline behavior:
+
+- Existing JP Scramble Crossing and CM bubble resources worked.
+- The CM page opened.
+- JP `Cm.ButtonPlayCm` did not match English `Watch Ad`.
+- Baseline swiped the already-open CM page, logged `No ads available`, and
+  finished while visible ad cards remained.
+
+Manual/candidate findings:
+
+- One manually selected ad launched directly without a JP-style confirmation.
+- One provider redirected to Google Play.
+- After waiting and returning, Global displayed `Claimed rewards.` and granted
+  crystals.
+- JP reward text did not match the English overlay.
+- Candidate EN resources recognized English `Watch Ad`, reward text, and an
+  interrupted-ad state.
+- One bounded candidate run claimed and dismissed a reward.
+- One bounded run returned to the CM selection page with no recognized reward or
+  failure dialog; a guard stopped safely instead of polling indefinitely.
+- A Meta/Facebook Marketplace provider produced an empty Scrcpy frame during
+  loading in one run.
+
+Conclusion: CM remains unknown/partial. Ad behavior varies too much to mark
+full support from a small number of provider paths.
+
+## Current event story probe
+
+During a World Link event, candidate resources reached the event-story list,
+handled the English voice-data dialog, and returned to the event-story list from
+a direct story-skip run.
+
+Generated EN resources were needed for:
+
+- `Event Story`;
+- `No Voice`;
+- story-menu `Skip`;
+- `View Next Episode`;
+- `Return to Episode List`;
+- final `Skip the story?` confirmation.
+
+A fresh uninterrupted `activity_story()` run from home completed the route and
+no-unread branch. The remaining gap is an unread-story run that enters playback
+from home and consumes the episode chain end to end.
+
+## Event shop probe
+
+During the same World Link event:
+
+- Generated EN resources recognized the English Event Exchange card.
+- Generated EN resources recognized the event-shop `Until` footer marker.
+- The task scanned the two visible World Link event tabs and exited without a
+  purchase because configured targets were not found.
+
+Still untested:
+
+- ordinary non-World-Link event inventory;
+- purchase confirmation;
+- insufficient-currency behavior;
+- no-target behavior across different event layouts.
+
+## Overall conclusion
+
+The Global / EN support path is realistic, but it should be implemented
+incrementally.
+
+The immediate work is configuration, package mapping, safe startup handling, and
+EN resource selection. Gifts and Missions are the most suitable first automation
+targets. Show automation can follow with tightly bounded tests. CM/ad support
+should remain last because provider behavior is variable and difficult to
+generalize from a small sample.


### PR DESCRIPTION
## 中文

这个 PR 添加了初步的 Global / EN 服务器兼容性文档。

内容包括：

* Global / EN 当前状态说明
* 已知阻塞点，例如目前 GUI 中无法选择 Global / EN、缺少 `com.sega.ColorfulStage.en` 包名映射
* JP 资源在 Global 页面上的初步复用测试结果
* 部分任务的本地兼容性测试记录
* Global / EN 的手动 smoke test checklist
* 英文版 README 草稿

这个 PR **只包含文档**，不声称当前已经正式支持 Global / EN，也不修改 JP / TW / CN 行为。

我希望先用这些文档整理可复现的测试结果，方便后续维护 Global / EN 支持。如果这些文档的目录结构、命名方式或范围需要调整，我很愿意根据维护者的建议修改。

## English

This PR adds initial documentation for Global / EN server compatibility.

It includes:

* Current Global / EN support status
* Known blockers, such as Global / EN not being selectable in the GUI and the missing `com.sega.ColorfulStage.en` package mapping
* Initial JP resource reuse checks against Global screens
* Local compatibility notes for selected tasks
* A manual smoke-test checklist for Global / EN
* A draft English README

This PR is **documentation-only**. It does not claim that Global / EN is officially supported yet, and it does not modify JP / TW / CN behavior.

The goal is to organize reproducible findings and provide a clearer starting point for future Global / EN maintenance. If the maintainers prefer a different directory structure, naming convention, or scope, I’m happy to adjust it.