### PR TITLE
feat: add Global EN server config / 添加国际服服务器配置

### DIFF
--- a/iaa/application/qt/models/mappings.py
+++ b/iaa/application/qt/models/mappings.py
@@ -7,6 +7,7 @@ from iaa.definitions.enums import (
     GameCharacter,
     LinkAccountOptions,
 )
+from iaa.definitions.consts import ServerName
 
 LIFECYCLE_TYPE_DISPLAY_MAP: dict[str, str] = {
     'mumu_v5': 'MuMu 12 (v5)',
@@ -21,12 +22,13 @@ CONNECTION_TYPE_DISPLAY_MAP: dict[str, str] = {
     'tcp': 'TCP / 无线',
 }
 
-SERVER_DISPLAY_MAP: dict[Literal['jp', 'tw', 'cn'], str] = {
+SERVER_DISPLAY_MAP: dict[ServerName, str] = {
     'jp': '日服',
     'tw': '台服',
     'cn': '国服',
+    'en': '国际服',
 }
-SERVER_VALUE_MAP: dict[str, Literal['jp', 'tw', 'cn']] = {value: key for key, value in SERVER_DISPLAY_MAP.items()}
+SERVER_VALUE_MAP: dict[str, ServerName] = {value: key for key, value in SERVER_DISPLAY_MAP.items()}
 
 LINK_DISPLAY_MAP: dict[LinkAccountOptions, str] = {
     'no': '不引继账号',

--- a/iaa/config/schemas.py
+++ b/iaa/config/schemas.py
@@ -7,6 +7,7 @@ from iaa.definitions.enums import (
     ChallengeLiveAward,
     ShopItem,
 )
+from iaa.definitions.consts import ServerName
 
 
 # ── 设备生命周期 ──────────────────────────────────────────────────────────────
@@ -73,7 +74,7 @@ class DeviceConfig(BaseModel):
 # ── 游戏配置（仅游戏层面） ────────────────────────────────────────────────────
 
 class GameConfig(BaseModel):
-    server: Literal['jp', 'tw', 'cn'] = 'jp'
+    server: ServerName = 'jp'
     link_account: LinkAccountOptions = 'no'
     """
     是否引继账号。

--- a/iaa/context.py
+++ b/iaa/context.py
@@ -5,6 +5,7 @@ from iaa.input import AdbKeyboardInput
 
 
 from .config.base import IaaConfig
+from .definitions.consts import ServerName
 from .definitions.errors import ContextNotInitializedError
 from iaa.progress import DummyTaskReporter, ProgressHub, TaskReporter
 
@@ -26,7 +27,7 @@ def conf() -> IaaConfig:
         raise ContextNotInitializedError()
     return config
 
-def server():
+def server() -> ServerName:
     return conf().game.server
 
 

--- a/iaa/definitions/consts.py
+++ b/iaa/definitions/consts.py
@@ -1,30 +1,36 @@
-from typing import Literal
+from typing import Literal, TypeAlias
+
+ServerName: TypeAlias = Literal['jp', 'tw', 'cn', 'en']
 
 PACKAGE_NAME_JP = 'com.sega.pjsekai'
 PACKAGE_NAME_CN = 'com.hermes.mk'
 PACKAGE_NAME_TW = 'com.hermes.mk.asia'
+PACKAGE_NAME_EN = 'com.sega.ColorfulStage.en'
 
-PACKAGE_NAME_MAP: dict[Literal['jp', 'tw', 'cn'], str] = {
+PACKAGE_NAME_MAP: dict[ServerName, str] = {
     'jp': PACKAGE_NAME_JP,
     'tw': PACKAGE_NAME_TW,
     'cn': PACKAGE_NAME_CN,
+    'en': PACKAGE_NAME_EN,
 }
 
 BUNDLE_ID_JP = 'com.sega.pjsekai'
 BUNDLE_ID_CN = 'com.hermes.mk'
 BUNDLE_ID_TW = 'com.hermes.mk.asia'
+BUNDLE_ID_EN = 'com.sega.ColorfulStage.en'
 
-BUNDLE_ID_MAP: dict[Literal['jp', 'tw', 'cn'], str] = {
+BUNDLE_ID_MAP: dict[ServerName, str] = {
     'jp': BUNDLE_ID_JP,
     'tw': BUNDLE_ID_TW,
     'cn': BUNDLE_ID_CN,
+    'en': BUNDLE_ID_EN,
 }
 
 
-def package_by_server(server: Literal['jp', 'tw', 'cn']) -> str:
+def package_by_server(server: ServerName) -> str:
     return PACKAGE_NAME_MAP.get(server, PACKAGE_NAME_JP)
 
-def bundle_id_by_server(server: Literal['jp', 'tw', 'cn']) -> str:
+def bundle_id_by_server(server: ServerName) -> str:
     return BUNDLE_ID_MAP.get(server, BUNDLE_ID_JP)
 
 def package_name() -> str:

--- a/tests/test_global_en_config.py
+++ b/tests/test_global_en_config.py
@@ -1,0 +1,24 @@
+import unittest
+
+from iaa.application.qt.models.mappings import SERVER_DISPLAY_MAP, SERVER_VALUE_MAP
+from iaa.config.schemas import GameConfig
+from iaa.definitions.consts import bundle_id_by_server, package_by_server
+
+
+class GlobalEnConfigTests(unittest.TestCase):
+    def test_game_config_accepts_en_server(self) -> None:
+        conf = GameConfig(server='en')
+
+        self.assertEqual(conf.server, 'en')
+
+    def test_global_package_and_bundle_mapping(self) -> None:
+        self.assertEqual(package_by_server('en'), 'com.sega.ColorfulStage.en')
+        self.assertEqual(bundle_id_by_server('en'), 'com.sega.ColorfulStage.en')
+
+    def test_global_server_is_exposed_to_settings_options(self) -> None:
+        self.assertIn('en', SERVER_DISPLAY_MAP)
+        self.assertEqual(SERVER_VALUE_MAP[SERVER_DISPLAY_MAP['en']], 'en')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 中文

这个 PR 添加 Global / EN 服务器的基础配置。

内容包括：

* 添加 `en` server 类型
* 在 GUI server 选项中显示 `国际服`
* 添加 Global / EN 的 Android package / bundle id：`com.sega.ColorfulStage.en`
* 添加基础测试，确认 `GameConfig(server="en")`、包名映射和 GUI 选项映射正常

这个 PR **只处理基础服务器配置**。
它不包含 EN resource variant、EN 资源适配，也不声称 Global / EN 任务已经可以正式使用。

后续资源适配会按照 kotonebot 的 variant / prefab 流程单独处理。

## English

This PR adds the basic Global / EN server configuration.

It includes:

* Adds the `en` server type
* Displays `国际服` in the GUI server options
* Adds the Global / EN Android package / bundle id: `com.sega.ColorfulStage.en`
* Adds basic tests for `GameConfig(server="en")`, package mapping, and GUI option mapping

This PR **only covers the base server configuration**.