### PR TITLE
feat: add EN resource variant / 添加国际服资源变体

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,6 @@ prefabs_module = "iaa.game_ui.elements"
 resource_path = "resources/"
 
 [tool.kotonebot.variant]                                                                                                                  
-variants = ["tw", "cn"]
+variants = ["tw", "cn", "en"]
 base = "jp"
 path_pattern = "nest"

--- a/resources/jp/cm/screenshot_ad_1.png.json
+++ b/resources/jp/cm/screenshot_ad_1.png.json
@@ -23,7 +23,8 @@
       },
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/cm/screenshot_ad_2.png.json
+++ b/resources/jp/cm/screenshot_ad_2.png.json
@@ -23,7 +23,8 @@
       },
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/cm/screenshot_ad_failed.png.json
+++ b/resources/jp/cm/screenshot_ad_failed.png.json
@@ -17,7 +17,8 @@
       "displayName": "",
       "variant_policy": {
         "tw": "require",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "exclude"
       }
     },
     "55658b39-fc12-401f-b3b2-9d2f8cfad57f": {
@@ -36,7 +37,8 @@
       "displayName": "",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/cm/screenshot_ap_recovered.png.json
+++ b/resources/jp/cm/screenshot_ap_recovered.png.json
@@ -17,7 +17,8 @@
       "displayName": "ライブボーナスを5回復しました。",
       "variant_policy": {
         "tw": "require",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/cm/screenshot_award.png.json
+++ b/resources/jp/cm/screenshot_award.png.json
@@ -17,7 +17,8 @@
       "displayName": "報酬を獲得しました",
       "variant_policy": {
         "tw": "require",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/cm/screenshot_cm_confirm.png.json
+++ b/resources/jp/cm/screenshot_cm_confirm.png.json
@@ -17,7 +17,8 @@
       "displayName": "視聴開始 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/cm/screenshot_cm_select.png.json
+++ b/resources/jp/cm/screenshot_cm_select.png.json
@@ -17,7 +17,8 @@
       "displayName": "播放广告 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/common_dialog/screenshot_award_claimed.png.json
+++ b/resources/jp/common_dialog/screenshot_award_claimed.png.json
@@ -17,7 +17,8 @@
       "displayName": "",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "86a9a7e4-e2c3-49d3-872c-c0d9b9c74b3c": {
@@ -36,7 +37,8 @@
       "displayName": "OK",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/common_dialog/screenshot_data_download.png.json
+++ b/resources/jp/common_dialog/screenshot_data_download.png.json
@@ -17,7 +17,8 @@
       "displayName": "建议 Wifi 环境下载文本",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "73b4fbe5-7a86-49d0-90e6-4792e1cda085": {
@@ -36,7 +37,8 @@
       "displayName": "ダウンロード",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/common_dialog/screenshot_tip_1.png.json
+++ b/resources/jp/common_dialog/screenshot_tip_1.png.json
@@ -17,7 +17,8 @@
       },
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/common_dialog/screenshot_tip_2.png.json
+++ b/resources/jp/common_dialog/screenshot_tip_2.png.json
@@ -17,7 +17,8 @@
       },
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/daily/screenshot_task_bonus.png.json
+++ b/resources/jp/daily/screenshot_task_bonus.png.json
@@ -17,7 +17,8 @@
       "displayName": "一括受け取り",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "5f4b378f-0b97-4721-aad5-a4f2bb6f4a21": {
@@ -51,7 +52,8 @@
       "displayName": "左上角返回按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_7day_award_1.png.json
+++ b/resources/jp/live/screenshot_7day_award_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "今週のチャレニメスラニブ報動",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "df78dcea-eed2-49ca-95d0-67066f5507ca": {
@@ -36,7 +37,8 @@
       "displayName": "挑战演出 每周奖励 水晶",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "d34fa417-e8da-4a14-9b83-c4e385863096": {
@@ -55,7 +57,8 @@
       "displayName": "挑战演出 每周奖励 音乐卡",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     },
     "d80c55a0-15ca-45a9-a24a-3cdc6a57c0d6": {
@@ -74,7 +77,8 @@
       "displayName": "挑战演出 每周奖励 奇迹晶石",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "875d9bca-2870-43c3-9531-92b040bfc590": {
@@ -93,7 +97,8 @@
       "displayName": "挑战演出 每周奖励 魔法之布",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "f90392bc-b7d4-491e-b2d3-ae216003d17a": {
@@ -112,7 +117,8 @@
       "displayName": "挑战演出 每周奖励 硬币",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "1f7662e4-53e0-43f9-9dab-839ca88ff9ad": {
@@ -131,7 +137,8 @@
       "displayName": "挑战演出 每周奖励 中级练习乐谱",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "23b1762d-e0f5-4230-b20f-4cfc4c6d511e": {
@@ -150,7 +157,8 @@
       "displayName": "挑战演出 每周奖励 奇异种子",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "0588ed35-9d61-439a-bd8e-2997713634a3": {
@@ -169,7 +177,8 @@
       "displayName": "挑战演出 每周奖励 魔法之线",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_7day_award_2.png.json
+++ b/resources/jp/live/screenshot_7day_award_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "この報酬を受け取ります。よろしいですか？",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "efb7440d-3b59-4973-9da2-1c1dfffae2c1": {
@@ -37,7 +38,8 @@
       "description": "挑战演出领取奖励弹窗",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_ap_multiplier_dialog.png.json
+++ b/resources/jp/live/screenshot_ap_multiplier_dialog.png.json
@@ -18,7 +18,8 @@
       "displayName": "ライフホーナスの消費量を設定します。",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "b6d937ba-7b8a-4908-9f2a-5e3c42c799c6": {
@@ -38,7 +39,8 @@
       "displayName": "AP 倍率 决定 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "2d6efdb5-633a-4251-ae5c-5d2b16638b9d": {

--- a/resources/jp/live/screenshot_auto_completed.png.json
+++ b/resources/jp/live/screenshot_auto_completed.png.json
@@ -17,7 +17,8 @@
       "displayName": "指定された回数のオートライプが完了しました。",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/live/screenshot_auto_set_dialog.png.json
+++ b/resources/jp/live/screenshot_auto_set_dialog.png.json
@@ -18,7 +18,8 @@
       "displayName": "自动编队 活动成员",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "ab73f9bb-7999-4282-bf33-b45f8e049b38": {
@@ -38,7 +39,8 @@
       "displayName": "自动编队 推荐",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "b57ec406-7be0-4220-b7c2-59d8570a8450": {
@@ -58,7 +60,8 @@
       "displayName": "自动编队 确定按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "9dd57d2f-2810-4caf-878e-eb7d70438211": {
@@ -77,7 +80,8 @@
       },
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_auto_settings.png.json
+++ b/resources/jp/live/screenshot_auto_settings.png.json
@@ -17,7 +17,8 @@
       "displayName": "自动演出直到耗尽 AP",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "04e53290-fc0d-4c03-acfa-f8f482deb54e": {
@@ -36,7 +37,8 @@
       "displayName": "确定自动演出设置",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_1.png.json
+++ b/resources/jp/live/screenshot_challenge_select_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "キャラクラーを選択レてください",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "59294cc5-bbb5-4568-bf81-24bd6cbb8dd5": {
@@ -36,7 +37,8 @@
       "displayName": "初音ミク",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "82997d1e-1f73-440a-82fb-88246e48ee2a": {
@@ -55,7 +57,8 @@
       "displayName": "鏡音リン",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "e3883fd0-5b36-4e2e-b657-f40c32a94216": {
@@ -74,7 +77,8 @@
       "displayName": "鏡音レン",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "5c660ff2-7f22-4968-8845-50bfc7ecc000": {
@@ -93,7 +97,8 @@
       "displayName": "巡音ルカ",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "0c8d55ec-5774-4b16-b019-5dc04d0f4dcc": {
@@ -112,7 +117,8 @@
       "displayName": "MEIKO",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e55d6310-79ab-4f2d-b6b3-2441fa6dbe66": {
@@ -131,7 +137,8 @@
       "displayName": "KAITO",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "a93d25b7-1025-4cb4-89da-44fa172ae19a": {
@@ -150,7 +157,8 @@
       "displayName": "组合「VIRTUAL SINGER」",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "3cec98a5-e17e-4a31-9afc-5ac75a7cd16f": {
@@ -169,7 +177,8 @@
       "displayName": "组合「Leo/need」",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "d10b9d2a-b562-420c-b3a5-09e4f651f89e": {
@@ -188,7 +197,8 @@
       "displayName": "组合「MORE MORE JUMP!」",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "95d2af7d-b475-466a-b435-9a79215a6eaf": {
@@ -207,7 +217,8 @@
       "displayName": "组合「Vivid BAD SQUAD」",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "654adfab-df80-4a7f-9183-d6d27f0c40f3": {
@@ -226,7 +237,8 @@
       "displayName": "组合「ワンダーランズｘショウタイム」",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "7f0c09b8-bf28-469d-84a4-dd6e188b5ecf": {
@@ -245,7 +257,8 @@
       "displayName": "组合「25時ナイトコードで」",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_2.png.json
+++ b/resources/jp/live/screenshot_challenge_select_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "星乃 一歌",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "2c1cd5be-19d4-4d04-bcc2-007a3a070a15": {
@@ -36,7 +37,8 @@
       "displayName": "天馬 咲希",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e111fa38-1ff4-49c7-b1bd-fd876cb5ee3b": {
@@ -55,7 +57,8 @@
       "displayName": "望月 穂波",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "0aa9773e-68b7-464d-b96e-70cf4a630505": {
@@ -74,7 +77,8 @@
       "displayName": "日野森 志歩",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_3.png.json
+++ b/resources/jp/live/screenshot_challenge_select_3.png.json
@@ -17,7 +17,8 @@
       "displayName": "花里みのり",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "71c61e81-b14e-4017-99a5-53e3ce0e394b": {
@@ -36,7 +37,8 @@
       "displayName": "桐谷遥",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "733b46d4-6030-4769-b2cf-ce0dd85bc923": {
@@ -55,7 +57,8 @@
       "displayName": "桃井愛莉",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "ba15954f-a44f-4f33-a638-1db5dc409e48": {
@@ -74,7 +77,8 @@
       "displayName": "日野森雫",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_4.png.json
+++ b/resources/jp/live/screenshot_challenge_select_4.png.json
@@ -17,7 +17,8 @@
       "displayName": "小豆沢",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "c65119a1-435d-4cda-92b5-f526c6cd770b": {
@@ -36,7 +37,8 @@
       "displayName": "白石杏",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "85bb0359-de82-427b-83b9-bd8abfc99ab6": {
@@ -55,7 +57,8 @@
       "displayName": "東雲彰人",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "ec3b566a-e8f1-42a8-9ea6-88e4c38b3e63": {
@@ -74,7 +77,8 @@
       "displayName": "青柳冬弥",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_5.png.json
+++ b/resources/jp/live/screenshot_challenge_select_5.png.json
@@ -17,7 +17,8 @@
       "displayName": "天馬司",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "6cd7b225-ef84-4219-9d6a-961b3abedffb": {
@@ -36,7 +37,8 @@
       "displayName": "鳳えむ",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "101c74a1-cde5-41fa-b2e9-26e7e476d55e": {
@@ -55,7 +57,8 @@
       "displayName": "草薙寧々",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "bbd3e850-7227-4f38-b1d3-14d97a10b239": {
@@ -74,7 +77,8 @@
       "displayName": "神代類",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_challenge_select_6.png.json
+++ b/resources/jp/live/screenshot_challenge_select_6.png.json
@@ -17,7 +17,8 @@
       "displayName": "宵崎奏",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "896881e6-2579-495e-935c-27d744542e1f": {
@@ -36,7 +37,8 @@
       "displayName": "朝比奈真冬",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "d6522a11-a1c1-4bb3-b886-0d21e8b63641": {
@@ -55,7 +57,8 @@
       "displayName": "東雲絵名",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "d6bf5ad6-2d47-4e1e-87db-e0883d7e950f": {
@@ -74,7 +77,8 @@
       "displayName": "暁山瑞希",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_in_live.png.json
+++ b/resources/jp/live/screenshot_in_live.png.json
@@ -18,7 +18,8 @@
       "displayName": "演出界面 右上角 LIFE 文本",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_live_award.png.json
+++ b/resources/jp/live/screenshot_live_award.png.json
@@ -18,7 +18,8 @@
       "displayName": "演出 RANK 奖励对话框标题",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "45d56f50-66ae-4298-bc64-a840dc786286": {
@@ -38,7 +39,8 @@
       "displayName": "演出 RANK 奖励对话框 关闭按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_live_clear.png.json
+++ b/resources/jp/live/screenshot_live_clear.png.json
@@ -18,7 +18,8 @@
       "displayName": "SCORERANK",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "exclude"
       }
     }
   }

--- a/resources/jp/live/screenshot_live_completed.png.json
+++ b/resources/jp/live/screenshot_live_completed.png.json
@@ -17,7 +17,8 @@
       "displayName": "",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "c913df93-6d3c-4e2c-9dc4-4ad9e6d3ac46": {
@@ -36,7 +37,8 @@
       "displayName": "前往歌曲选择 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_live_completed_1.png.json
+++ b/resources/jp/live/screenshot_live_completed_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "次へ",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_live_select.png.json
+++ b/resources/jp/live/screenshot_live_select.png.json
@@ -17,7 +17,8 @@
       "displayName": "画面上方水晶数量图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e5633df7-0abd-4ef6-84b6-3ebfe1df3fbf": {
@@ -64,7 +65,8 @@
       "displayName": "单人演出 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e01b6a1d-be60-4323-8152-94b56bf9488a": {
@@ -83,7 +85,8 @@
       "displayName": "多人演出 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "db8c1d40-9e04-43b9-affe-70c9d0ffd89d": {
@@ -102,7 +105,8 @@
       "displayName": "挑战演出 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e0fbf1c6-bc8c-4da5-b0db-03b5ba35e393": {
@@ -121,7 +125,8 @@
       "displayName": "虚拟演唱会 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "76c00bd4-0a0e-454e-be4f-76aea6d737d2": {

--- a/resources/jp/live/screenshot_no_enough_ap.png.json
+++ b/resources/jp/live/screenshot_no_enough_ap.png.json
@@ -18,7 +18,8 @@
       "description": "当 AP 为 0 时开启 AUTO 的提示",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_player_rank_up.png.json
+++ b/resources/jp/live/screenshot_player_rank_up.png.json
@@ -18,7 +18,8 @@
       "displayName": "升级时的演出能量文本",
       "variant_policy": {
         "tw": "require",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_song_select.png.json
+++ b/resources/jp/live/screenshot_song_select.png.json
@@ -17,7 +17,8 @@
       "displayName": "決定",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "6446c387-cacf-4147-a310-bdee6160e3c3": {
@@ -60,7 +61,8 @@
       "displayName": "切换到封面视图",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "e6d1216a-3594-44fb-aa13-efd9320cec45": {
@@ -92,7 +94,8 @@
       "displayName": "歌曲选择页面 搜索图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "73c78678-59c9-4d6b-80ff-6c887f7cbaa1": {
@@ -112,7 +115,8 @@
       "displayName": "歌曲选择 Vo.",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "7c27897f-70c5-4d24-a0af-95be8d45b5a9": {
@@ -132,7 +136,8 @@
       "displayName": "歌曲选择 随机按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_song_select_2.png.json
+++ b/resources/jp/live/screenshot_song_select_2.png.json
@@ -18,7 +18,8 @@
       "displayName": "歌曲选择页面 清空搜索按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_song_select_jacket.png.json
+++ b/resources/jp/live/screenshot_song_select_jacket.png.json
@@ -17,7 +17,8 @@
       "displayName": "切换到列表视图",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_unit_select.png.json
+++ b/resources/jp/live/screenshot_unit_select.png.json
@@ -17,7 +17,8 @@
       "displayName": "开始演出 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "c6abf269-d131-45f6-983c-5f0d911a987a": {
@@ -36,7 +37,8 @@
       "displayName": "自动演出 设置按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "564d2236-f9d6-4d4b-9c10-8c8b31143a81": {
@@ -55,7 +57,8 @@
       "displayName": "自动演出 ON",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "c4eb4872-6d30-4804-8594-9b98a9add2da": {
@@ -75,7 +78,8 @@
       "displayName": "おすすめ編成",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "a7d4c0eb-9a52-4df2-b3d3-2e79da8c6216": {
@@ -95,7 +99,8 @@
       "displayName": "AP 条右侧设置按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/live/screenshot_unit_select_2.png.json
+++ b/resources/jp/live/screenshot_unit_select_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "自动演出 OFF",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_link.png.json
+++ b/resources/jp/login/screenshot_link.png.json
@@ -18,7 +18,8 @@
       "displayName": "Googleアカウントで連携",
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     },
     "b34e62d0-3932-4058-9927-e4bb660a1d5a": {
@@ -38,7 +39,8 @@
       "displayName": "GooglePlayで連携",
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_link_confirm.png.json
+++ b/resources/jp/login/screenshot_link_confirm.png.json
@@ -18,7 +18,8 @@
       "displayName": "連携",
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_link_finished.png.json
+++ b/resources/jp/login/screenshot_link_finished.png.json
@@ -17,7 +17,8 @@
       "displayName": "プレイヤーデータの連携が完了しました。",
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_menu.png.json
+++ b/resources/jp/login/screenshot_menu.png.json
@@ -17,7 +17,8 @@
       "displayName": "「データ引き継ぎ」的图标",
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_notification.png.json
+++ b/resources/jp/login/screenshot_notification.png.json
@@ -18,7 +18,8 @@
       "displayName": "通知弹窗 左上角图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/login/screenshot_title.png.json
+++ b/resources/jp/login/screenshot_title.png.json
@@ -17,7 +17,8 @@
       "displayName": "右上角菜单按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/map/screenshot_intersection_1.png.json
+++ b/resources/jp/map/screenshot_intersection_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "交叉口 背景大楼 100 红色 LOGO",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "8e5c2cb1-f34e-4f66-a2d1-42b6ebe66f50": {
@@ -36,7 +37,8 @@
       "displayName": "打开地图 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "1429f33a-8793-401e-b937-39974e1501f1": {
@@ -56,7 +58,8 @@
       "displayName": "工具栏 LIVE 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "exclude"
       }
     },
     "5df90065-4f75-4f85-a9d2-2d9f8c418394": {
@@ -89,7 +92,8 @@
       "displayName": "首页 礼物按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e153dec8-abf8-42c5-9a08-b8f7e16c7792": {
@@ -108,7 +112,8 @@
       "displayName": "首页 任务按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e6e9b497-82e4-4721-8b52-cfa6c80f8cea": {
@@ -128,7 +133,8 @@
       "displayName": "工具栏 STORY 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "f4235297-c9c1-496e-a4a6-c17e6addb5c7": {
@@ -148,7 +154,8 @@
       "displayName": "工具栏 MYSEKAI 按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/map/screenshot_intersection_2.png.json
+++ b/resources/jp/map/screenshot_intersection_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "看广告提示图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/map/screenshot_map_1.png.json
+++ b/resources/jp/map/screenshot_map_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "スクランブル交差点",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "f7f2f77c-49dd-4c87-9010-231e1d1c6300": {
@@ -36,7 +37,8 @@
       "displayName": "音楽ショップ",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "af87f0e8-b408-48e1-8234-631fa8822dda": {
@@ -55,7 +57,8 @@
       "displayName": "关闭地图 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "4462ae7e-efd8-4c17-af15-a029409c8a81": {
@@ -74,7 +77,8 @@
       "displayName": "前往世界 按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/map/screenshot_map_sekai_1.png.json
+++ b/resources/jp/map/screenshot_map_sekai_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "現実世界へ",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/map/screenshot_new.png.json
+++ b/resources/jp/map/screenshot_new.png.json
@@ -24,7 +24,8 @@
       "displayName": "区域未读对话 NEW 标志",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "2bcdac90-5adc-4137-a491-8bbeae113f92": {

--- a/resources/jp/mysekai/screenshot_crowded.png.json
+++ b/resources/jp/mysekai/screenshot_crowded.png.json
@@ -17,7 +17,8 @@
       },
       "variant_policy": {
         "tw": "exclude",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "inherit"
       }
     },
     "31e1994d-e806-4b08-9fe3-5e9b769a76dd": {
@@ -33,6 +34,9 @@
           "y2": 444.05720463241937
         },
         "fixed": true
+      },
+      "variant_policy": {
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/mysekai/screenshot_home.png.json
+++ b/resources/jp/mysekai/screenshot_home.png.json
@@ -17,7 +17,8 @@
       },
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       },
       "displayName": "烤森 布局按钮图标"
     }

--- a/resources/jp/shop/screenshot_amount_dialog.png.json
+++ b/resources/jp/shop/screenshot_amount_dialog.png.json
@@ -18,7 +18,8 @@
       },
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "b6a87f73-79ed-491e-b7c3-9fa584680827": {
@@ -38,7 +39,8 @@
       },
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "5755f9a0-cf33-4372-bc21-8aea136efb02": {
@@ -56,7 +58,8 @@
       },
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "c9ee51d4-2cf0-454d-b2e7-7657a61994f9": {
@@ -75,7 +78,8 @@
       },
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/shop/screenshot_event_shop.png.json
+++ b/resources/jp/shop/screenshot_event_shop.png.json
@@ -17,7 +17,8 @@
       },
       "displayName": "卡片商品 Lv1 文本",
       "variant_policy": {
-        "tw": "require"
+        "tw": "require",
+        "en": "inherit"
       }
     },
     "c9269644-b1e1-430e-b4a6-8696175d3c90": {
@@ -35,7 +36,8 @@
         "fixed": true
       },
       "variant_policy": {
-        "tw": "require"
+        "tw": "require",
+        "en": "inherit"
       }
     },
     "af2fa909-5a1c-4253-b4e6-e223f82773c2": {
@@ -53,7 +55,8 @@
         "fixed": true
       },
       "variant_policy": {
-        "tw": "require"
+        "tw": "require",
+        "en": "inherit"
       }
     },
     "121a6893-e007-4bb7-b41f-cbe608dc45f2": {
@@ -72,7 +75,8 @@
       },
       "displayName": "活动商店最下方的まで",
       "variant_policy": {
-        "tw": "require"
+        "tw": "require",
+        "en": "inherit"
       }
     },
     "8dec26b6-85a8-4ece-afbb-6f2fb610fbe9": {
@@ -90,7 +94,8 @@
       },
       "displayName": "活动商店 列表",
       "variant_policy": {
-        "tw": "inherit"
+        "tw": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/shop/screenshot_exchange_list.png.json
+++ b/resources/jp/shop/screenshot_exchange_list.png.json
@@ -18,7 +18,8 @@
       "displayName": "活动交换所",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/shop/screenshot_exchanged_message.png.json
+++ b/resources/jp/shop/screenshot_exchanged_message.png.json
@@ -18,7 +18,8 @@
       "displayName": "交換が完了しました",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/shop/screenshot_menu.png.json
+++ b/resources/jp/shop/screenshot_menu.png.json
@@ -18,7 +18,8 @@
       "displayName": "交换所",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_activity.png.json
+++ b/resources/jp/story/screenshot_activity.png.json
@@ -17,7 +17,8 @@
       "displayName": "ランキニグ 按钮图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "e951831d-be2a-4501-b39c-b60c8804a7f5": {
@@ -36,7 +37,8 @@
       "displayName": "イベントストーリー 按钮图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_episode_list_2.png.json
+++ b/resources/jp/story/screenshot_episode_list_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "イベントストーリー",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "246abd8d-887f-4f38-9be3-3bb8bcbcfa3a": {
@@ -36,7 +37,8 @@
       "displayName": "第8話",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "f7b052bd-4ff3-4d13-b36f-bdae7e9c8f44": {
@@ -68,7 +70,8 @@
       "displayName": "剧情分集列表 右上角书签按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "7438ba2d-1971-482c-bd87-62e0ecdc7c53": {
@@ -88,7 +91,8 @@
       "displayName": "分集列表 左上角返回按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_mv_paused.png.json
+++ b/resources/jp/story/screenshot_mv_paused.png.json
@@ -18,7 +18,8 @@
       "displayName": "MV 播放已暂停文本",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "306ef78a-cf2c-4e29-8361-cff97e42c4ef": {
@@ -38,7 +39,8 @@
       "displayName": "MV 播放已暂停 跳过按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_start_story_1.png.json
+++ b/resources/jp/story/screenshot_start_story_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "次のスト一リーを連続で読む",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "abbfd906-7b6d-4d5c-81ef-52a7d1cf460e": {
@@ -36,7 +37,8 @@
       "displayName": "ボイスなし",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "052adf6d-e689-44ff-8fb0-f0d1f7239548": {
@@ -55,7 +57,8 @@
       "displayName": "ボイステータをブウニロートしてストーリーを読みますか？",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_1.png.json
+++ b/resources/jp/story/screenshot_story_1.png.json
@@ -17,7 +17,8 @@
       "displayName": "剧情阅读 右上角菜单按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_2.png.json
+++ b/resources/jp/story/screenshot_story_2.png.json
@@ -17,7 +17,8 @@
       "displayName": "スキップ 按钮图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "686db7b7-bca3-4c11-96af-25d1142f6c23": {
@@ -36,7 +37,8 @@
       "displayName": "早送り 按钮图标",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_enter_1.png.json
+++ b/resources/jp/story/screenshot_story_enter_1.png.json
@@ -18,7 +18,8 @@
       "displayName": "主线剧情按钮 右侧的预览图片",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_list.png.json
+++ b/resources/jp/story/screenshot_story_list.png.json
@@ -18,7 +18,8 @@
       "displayName": "故事列表 筛选按钮",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "inherit"
       }
     },
     "8f2149e7-d32c-45e2-b60f-b8b5f681b29b": {
@@ -38,7 +39,8 @@
       "displayName": "故事列表 进入按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "e710ba9f-22f3-4f2b-978f-5d385b91787f": {
@@ -70,7 +72,8 @@
       "displayName": "故事列表 左侧展开按队查看按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_list_filter.png.json
+++ b/resources/jp/story/screenshot_story_list_filter.png.json
@@ -18,7 +18,8 @@
       "displayName": "故事列表 筛选弹窗 确认按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     },
     "9b2c08fb-f2ff-4598-8974-819caac34249": {
@@ -38,7 +39,8 @@
       "displayName": "故事列表 筛选弹窗 未读/跳过 单选",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_skip_dialog.png.json
+++ b/resources/jp/story/screenshot_story_skip_dialog.png.json
@@ -18,7 +18,8 @@
       "displayName": "次を読む",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/jp/story/screenshot_story_skip_dialog_2.png.json
+++ b/resources/jp/story/screenshot_story_skip_dialog_2.png.json
@@ -20,7 +20,8 @@
       "description": "跳过最后一话时跳过弹窗提示的跳过按钮",
       "variant_policy": {
         "tw": "require",
-        "cn": "require"
+        "cn": "require",
+        "en": "inherit"
       }
     }
   }

--- a/resources/tw/login/screenshot_announcements.png.json
+++ b/resources/tw/login/screenshot_announcements.png.json
@@ -18,7 +18,8 @@
       "displayName": "通知弹窗 SEKAI Announcements",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "inherit"
+        "cn": "inherit",
+        "en": "exclude"
       }
     }
   }

--- a/resources/tw/map/screenshot_intersection_1_1.png.json
+++ b/resources/tw/map/screenshot_intersection_1_1.png.json
@@ -18,7 +18,8 @@
       "displayName": "工具栏 LIVE 按钮（台服活动变体）",
       "variant_policy": {
         "tw": "inherit",
-        "cn": "exclude"
+        "cn": "exclude",
+        "en": "exclude"
       }
     }
   }


### PR DESCRIPTION
## 中文

这个 PR 添加 Global / EN 的资源 variant 基础配置，并指向 `feat/en-server` 集成分支。

内容包括：

- 添加 `en` resource variant 配置
- 为后续 Global / EN 资源适配准备 kotonebot resource variant 流程
- 保持实际 EN 资源文件和任务兼容性修改在后续 PR 中处理

这个 PR **只处理资源 variant 的基础配置**。  
它不包含大批量 EN resources，也不声称 Global / EN 任务已经可以正式使用。

后续 EN 资源会按照 kotonebot 的 `.png + .json` metadata、Prefab、`require` / `inherit` / `exclude` 机制继续拆成较小 PR。

## English

This PR adds the base Global / EN resource variant configuration and targets the `feat/en-server` integration branch.

It includes:

- Adds the `en` resource variant configuration
- Prepares the kotonebot resource variant workflow for future Global / EN resource adaptation
- Keeps actual EN resource files and task compatibility changes for follow-up PRs

This PR **only covers the base resource variant setup**.  
It does not add a large batch of EN resources or claim that Global / EN tasks are officially usable yet.

Future EN resources will be handled through kotonebot’s `.png + .json` metadata, Prefab, and `require` / `inherit` / `exclude` workflow in smaller follow-up PRs.