### PR TITLE
fix: support maximum auto live AP multiplier / 支持自动演出最大 AP 倍率

### DIFF
--- a/iaa/application/qt/forms/settings_form.py
+++ b/iaa/application/qt/forms/settings_form.py
@@ -545,14 +545,14 @@ def build_settings_form(
                 key='live.apMultiplier',
                 label='AP 倍率',
                 ref=ref(ctx.conf.live.ap_multiplier).map(
-                    to_ui=lambda v: '保持现状' if v is None else str(v),
+                    to_ui=lambda v: '保持现状' if v is None else ('最大值' if v == 'maximum' else str(v)),
                     from_ui=lambda v: (
                         None
                         if str(v) == '保持现状'
-                        else ('maximum' if str(v) == 'maximum' else int(str(v)))
+                        else ('maximum' if str(v) == '最大值' else int(str(v)))
                     ),
                 ),
-                options=['保持现状', 'maximum', *[str(i) for i in range(0, 11)]],
+                options=['保持现状', '最大值', *[str(i) for i in range(0, 11)]],
             )
             Checkbox(
                 key='live.autoSetUnit',

--- a/iaa/application/qt/forms/settings_form.py
+++ b/iaa/application/qt/forms/settings_form.py
@@ -546,9 +546,13 @@ def build_settings_form(
                 label='AP 倍率',
                 ref=ref(ctx.conf.live.ap_multiplier).map(
                     to_ui=lambda v: '保持现状' if v is None else str(v),
-                    from_ui=lambda v: None if str(v) == '保持现状' else int(str(v)),
+                    from_ui=lambda v: (
+                        None
+                        if str(v) == '保持现状'
+                        else ('maximum' if str(v) == 'maximum' else int(str(v)))
+                    ),
                 ),
-                options=['保持现状', *[str(i) for i in range(0, 11)]],
+                options=['保持现状', 'maximum', *[str(i) for i in range(0, 11)]],
             )
             Checkbox(
                 key='live.autoSetUnit',

--- a/iaa/application/qt/models/auto_live.py
+++ b/iaa/application/qt/models/auto_live.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from iaa.config.live_presets import AutoLivePreset
-from iaa.tasks.live.live import ListLoopPlan, SingleLoopPlan
+from iaa.tasks.live.live import ApMultiplier, ListLoopPlan, SingleLoopPlan
 
 SONG_KEEP_UNCHANGED = '保持不变'
 SONG_NAME_OPTIONS = [
@@ -39,11 +39,13 @@ def auto_live_payload_to_plan(payload: dict[str, Any]) -> SingleLoopPlan | ListL
         raise ValueError(f'未知的次数模式：{count_mode}')
 
     if ap_multiplier_raw in (None, '', '保持现状'):
-        ap_multiplier: int | None = None
+        ap_multiplier: ApMultiplier = None
+    elif ap_multiplier_raw == 'maximum':
+        ap_multiplier = 'maximum'
     else:
         ap_multiplier = int(ap_multiplier_raw)
         if not (0 <= ap_multiplier <= 10):
-            raise ValueError('AP 倍率必须在 0 到 10 之间。')
+            raise ValueError('AP 倍率必须在 0 到 10 之间，或为 maximum。')
 
     if loop_mode == 'single':
         return SingleLoopPlan(

--- a/iaa/application/qt/qml/dialogs/AutoLiveDialog.qml
+++ b/iaa/application/qt/qml/dialogs/AutoLiveDialog.qml
@@ -40,6 +40,14 @@ Dialog {
         }
     }
 
+    function apMultiplierLabel(value) {
+        return value === "maximum" ? "最大值" : value
+    }
+
+    function apMultiplierValue(label) {
+        return label === "最大值" ? "maximum" : label
+    }
+
     onOpened: {
         presets = JSON.parse(runController.builtinAutoPresetsJson())
         formData = defaultPayload()
@@ -129,10 +137,10 @@ Dialog {
         RowLayout {
             Label { text: "AP 倍率" }
             Select {
-                model: ["保持现状", "maximum", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+                model: ["保持现状", "最大值", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
                 enabled: formData.playMode !== "script_auto"
-                currentIndex: model.indexOf(formData.apMultiplier)
-                onActivated: formData = Object.assign({}, formData, { apMultiplier: model[currentIndex] })
+                currentIndex: model.indexOf(root.apMultiplierLabel(formData.apMultiplier))
+                onActivated: formData = Object.assign({}, formData, { apMultiplier: root.apMultiplierValue(model[currentIndex]) })
             }
         }
 

--- a/iaa/application/qt/qml/dialogs/AutoLiveDialog.qml
+++ b/iaa/application/qt/qml/dialogs/AutoLiveDialog.qml
@@ -129,7 +129,7 @@ Dialog {
         RowLayout {
             Label { text: "AP 倍率" }
             Select {
-                model: ["保持现状", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+                model: ["保持现状", "maximum", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
                 enabled: formData.playMode !== "script_auto"
                 currentIndex: model.indexOf(formData.apMultiplier)
                 onActivated: formData = Object.assign({}, formData, { apMultiplier: model[currentIndex] })

--- a/iaa/config/schemas.py
+++ b/iaa/config/schemas.py
@@ -103,8 +103,8 @@ class LiveConfig(BaseModel):
     """
     auto_set_unit: bool = False
     """演出前是否自动编队"""
-    ap_multiplier: int | None = 10
-    """AP 倍率。None 表示保持现状。"""
+    ap_multiplier: int | Literal['maximum'] | None = 'maximum'
+    """AP 倍率。'maximum' 表示当前可用最大值，None 表示保持现状。"""
     append_fc: bool = False
     """是否在常规演出后追加一次 Full Combo 演出。"""
     prepend_random: bool = False

--- a/iaa/main.py
+++ b/iaa/main.py
@@ -62,9 +62,8 @@ def add_auto_live_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         '--ap-multiplier',
-        type=int,
-        choices=range(0, 11),
-        help='auto_live only: set AP multiplier to 0-10 before starting; omit to keep current',
+        choices=['maximum', *[str(i) for i in range(0, 11)]],
+        help='auto_live only: set AP multiplier to 0-10 or maximum before starting; omit to keep current',
     )
 
 

--- a/iaa/tasks/live/live.py
+++ b/iaa/tasks/live/live.py
@@ -19,6 +19,7 @@ LiveMode = Literal['all'] | Literal['once'] | Literal['script'] | int | None
 SoloPlayMode = Literal['game_auto', 'script_auto']
 SongChoiceMode = Literal['current', 'specified', 'random']
 LoopSongMode = Literal['list_next', 'random']
+ApMultiplier = int | Literal['maximum'] | None
 PrefabClass = TypeVar('PrefabClass', bound=Prefab)
 ChallengeCharacterPrefab = tuple[PrefabClass, PrefabClass | None]
 
@@ -28,7 +29,7 @@ class LivePlan(BaseModel):
     
     play_mode: SoloPlayMode = 'game_auto'
     debug_enabled: bool = False
-    ap_multiplier: int | None = None
+    ap_multiplier: ApMultiplier = None
     auto_set_unit: bool = False
 
 
@@ -112,7 +113,7 @@ def select_song(song_name: str):
         kbd.enter()
     sleep(0.5)
 
-def _configure_ap_multiplier(ap_multiplier: int) -> None:
+def _configure_ap_multiplier(ap_multiplier: int | Literal['maximum']) -> None:
     rep = task_reporter()
     logger.info(f'Setting AP multiplier to {ap_multiplier}.')
     rep.message('设置 AP 倍率')
@@ -124,44 +125,70 @@ def _configure_ap_multiplier(ap_multiplier: int) -> None:
             break
         elif R.Live.ButtonApMultiplierSettings.try_click():
             logger.debug('Clicked AP multiplier settings button.')
-    # 执行
-    retry_count = 0
-    def _set(ap_multiplier: int) -> bool:
-        # 设置 AP 倍率
+    def _read_current_multiplier() -> int:
         current_multiplier = ocr.ocr(R.Live.ApMultiplierDialog.BoxApNumber).squash().numbers()
         if not current_multiplier:
             raise RuntimeError('Failed to read current AP multiplier.')
-        current_multiplier = int(current_multiplier[0])
-        logger.debug(f'Current AP multiplier: {current_multiplier}, target: {ap_multiplier}')
-        # 计算点击方向与次数
-        if current_multiplier < ap_multiplier:
-            button = R.Live.ApMultiplierDialog.PointPlus
-            times = ap_multiplier - current_multiplier
-        elif current_multiplier > ap_multiplier:
-            button = R.Live.ApMultiplierDialog.PointMinus
-            times = current_multiplier - ap_multiplier
-        else:
-            logger.debug('Current AP multiplier already at target.')
-            return True
-        # 执行
-        for i in range(times):
-            device.click(button)
-            logger.debug(
-                f'Clicked AP multiplier {"plus" if button == R.Live.ApMultiplierDialog.PointPlus else "minus"} button. ({i + 1}/{times})'
-            )
+        return int(current_multiplier[0])
+
+    def _set_maximum() -> None:
+        previous_multiplier: int | None = None
+        for i in range(12):
+            device.screenshot()
+            current_multiplier = _read_current_multiplier()
+            logger.debug(f'Current AP multiplier while finding maximum: {current_multiplier}')
+            if previous_multiplier is not None:
+                if current_multiplier == previous_multiplier:
+                    logger.info(f'Maximum AP multiplier reached: {current_multiplier}.')
+                    return
+                if current_multiplier < previous_multiplier:
+                    raise RuntimeError('AP multiplier decreased after clicking plus.')
+            previous_multiplier = current_multiplier
+            device.click(R.Live.ApMultiplierDialog.PointPlus)
+            logger.debug(f'Clicked AP multiplier plus button while finding maximum. ({i + 1}/12)')
             sleep(0.3)
-        return False
-    while True:
-        device.screenshot()
-        try:
-            if _set(ap_multiplier):
-                break
-        except Exception:
-            logger.exception('Error setting AP multiplier')
-        sleep(0.5)
-        retry_count += 1
-        if retry_count >= 5:
-            raise RuntimeError('Failed to set AP multiplier after 5 attempts.')
+        raise RuntimeError('Failed to find maximum AP multiplier after 12 attempts.')
+
+    # 执行
+    if ap_multiplier == 'maximum':
+        _set_maximum()
+    else:
+        retry_count = 0
+
+        def _set(ap_multiplier: int) -> bool:
+            # 设置 AP 倍率
+            current_multiplier = _read_current_multiplier()
+            logger.debug(f'Current AP multiplier: {current_multiplier}, target: {ap_multiplier}')
+            # 计算点击方向与次数
+            if current_multiplier < ap_multiplier:
+                button = R.Live.ApMultiplierDialog.PointPlus
+                times = ap_multiplier - current_multiplier
+            elif current_multiplier > ap_multiplier:
+                button = R.Live.ApMultiplierDialog.PointMinus
+                times = current_multiplier - ap_multiplier
+            else:
+                logger.debug('Current AP multiplier already at target.')
+                return True
+            # 执行
+            for i in range(times):
+                device.click(button)
+                logger.debug(
+                    f'Clicked AP multiplier {"plus" if button == R.Live.ApMultiplierDialog.PointPlus else "minus"} button. ({i + 1}/{times})'
+                )
+                sleep(0.3)
+            return False
+
+        while True:
+            device.screenshot()
+            try:
+                if _set(ap_multiplier):
+                    break
+            except Exception:
+                logger.exception('Error setting AP multiplier')
+            sleep(0.5)
+            retry_count += 1
+            if retry_count >= 5:
+                raise RuntimeError('Failed to set AP multiplier after 5 attempts.')
     # 然后关闭弹窗
     R.Live.ApMultiplierDialog.ButtonConfirm.wait().click()
     sleep(0.5)
@@ -402,7 +429,7 @@ def _prepare_solo_live(song_select_mode: SongChoiceMode | Literal['list_next'], 
 def _start_single_live_run(
     live_mode: LiveMode,
     auto_set_unit: bool,
-    ap_multiplier: int | None,
+    ap_multiplier: ApMultiplier,
     song_select_mode: SongChoiceMode,
     song_name: str | None,
     debug_enabled: bool = False,
@@ -424,7 +451,7 @@ def start_auto_live(
     finish_pre_check: Callable[[], tuple[bool, bool]] | None = None,
     debug_enabled: bool = False,
     auto_set_unit: bool = False,
-    ap_multiplier: int | None = None,
+    ap_multiplier: ApMultiplier = None,
 ) -> bool:
     """
     前置：位于编队界面\n
@@ -447,7 +474,7 @@ def start_auto_live(
         如果 `should_skip` 为 True，则 `should_break` 会被忽略。
     :param debug_enabled: 是否启用调试模式，启用后会在自动演出时显示更多日志，并在脚本自动演出时显示节奏游戏分析器的调试信息。
     :param auto_set_unit: 是否在演出前自动编队
-    :param ap_multiplier: AP 倍率，范围 [0, 10]。若为数字，表示演出前自动设置倍率为对应值；若为 None，表示保持现状。
+    :param ap_multiplier: AP 倍率，范围 [0, 10]；若为 "maximum"，表示设置为当前可用最大值；若为 None，表示保持现状。
     :raises NotImplementedError: 如果未实现的功能被调用。
     :return: 若为 False，表示因为 AP 不足没有进行演出。
     """
@@ -500,8 +527,8 @@ def solo_live(plan: OncePlan | SingleLoopPlan | ListLoopPlan):
     """
     if isinstance(plan, (SingleLoopPlan, ListLoopPlan)) and plan.loop_count is not None and plan.loop_count <= 0:
         raise ValueError('loop_count must be positive.')
-    if plan.ap_multiplier is not None and not (0 <= plan.ap_multiplier <= 10):
-        raise ValueError('ap_multiplier must be between 0 and 10.')
+    if plan.ap_multiplier is not None and plan.ap_multiplier != 'maximum' and not (0 <= plan.ap_multiplier <= 10):
+        raise ValueError('ap_multiplier must be between 0 and 10, "maximum", or None.')
     if isinstance(plan, (OncePlan, SingleLoopPlan)) and plan.song_select_mode == 'specified' and not plan.song_name:
         raise ValueError('song_name is required when song_select_mode is specified.')
     reporter = task_reporter()
@@ -553,13 +580,16 @@ def solo_live(plan: OncePlan | SingleLoopPlan | ListLoopPlan):
             first_run = True
             for _ in Loop():
                 _prepare_solo_live(plan.loop_song_mode, None)
-                start_auto_live(
+                if not start_auto_live(
                     'once' if plan.play_mode == 'game_auto' else 'script',
                     return_to='home',
                     debug_enabled=plan.debug_enabled,
                     auto_set_unit=auto_set_unit,
                     ap_multiplier=plan.ap_multiplier if first_run else None,
-                )
+                ):
+                    logger.info('No AP left for list loop. Stopping.')
+                    go_home()
+                    break
                 first_run = False
                 count += 1
                 logger.info(f'Song looped. {count}/{max_count}')

--- a/iaa/tasks/live/live.py
+++ b/iaa/tasks/live/live.py
@@ -140,6 +140,7 @@ def _configure_ap_multiplier(ap_multiplier: int | Literal['maximum']) -> None:
             plus_btn.click()
             logger.debug(f'Clicked AP multiplier plus button while finding maximum. ({i + 1}/12)')
             sleep(0.3)
+            device.screenshot()
         raise RuntimeError('Failed to find maximum AP multiplier after 12 attempts.')
 
     # 执行

--- a/iaa/tasks/live/live.py
+++ b/iaa/tasks/live/live.py
@@ -132,19 +132,12 @@ def _configure_ap_multiplier(ap_multiplier: int | Literal['maximum']) -> None:
         return int(current_multiplier[0])
 
     def _set_maximum() -> None:
-        previous_multiplier: int | None = None
         for i in range(12):
-            device.screenshot()
-            current_multiplier = _read_current_multiplier()
-            logger.debug(f'Current AP multiplier while finding maximum: {current_multiplier}')
-            if previous_multiplier is not None:
-                if current_multiplier == previous_multiplier:
-                    logger.info(f'Maximum AP multiplier reached: {current_multiplier}.')
-                    return
-                if current_multiplier < previous_multiplier:
-                    raise RuntimeError('AP multiplier decreased after clicking plus.')
-            previous_multiplier = current_multiplier
-            device.click(R.Live.ApMultiplierDialog.PointPlus)
+            plus_btn = R.Live.ApMultiplierDialog.ButtonPlus.q(enabled=True).find()
+            if plus_btn is None:
+                logger.info('Maximum AP multiplier reached.')
+                return
+            plus_btn.click()
             logger.debug(f'Clicked AP multiplier plus button while finding maximum. ({i + 1}/12)')
             sleep(0.3)
         raise RuntimeError('Failed to find maximum AP multiplier after 12 attempts.')
@@ -161,20 +154,20 @@ def _configure_ap_multiplier(ap_multiplier: int | Literal['maximum']) -> None:
             logger.debug(f'Current AP multiplier: {current_multiplier}, target: {ap_multiplier}')
             # 计算点击方向与次数
             if current_multiplier < ap_multiplier:
-                button = R.Live.ApMultiplierDialog.PointPlus
+                button = R.Live.ApMultiplierDialog.ButtonPlus
+                button_name = 'plus'
                 times = ap_multiplier - current_multiplier
             elif current_multiplier > ap_multiplier:
-                button = R.Live.ApMultiplierDialog.PointMinus
+                button = R.Live.ApMultiplierDialog.ButtonMinus
+                button_name = 'minus'
                 times = current_multiplier - ap_multiplier
             else:
                 logger.debug('Current AP multiplier already at target.')
                 return True
             # 执行
             for i in range(times):
-                device.click(button)
-                logger.debug(
-                    f'Clicked AP multiplier {"plus" if button == R.Live.ApMultiplierDialog.PointPlus else "minus"} button. ({i + 1}/{times})'
-                )
+                button.click()
+                logger.debug(f'Clicked AP multiplier {button_name} button. ({i + 1}/{times})')
                 sleep(0.3)
             return False
 

--- a/resources/jp/live/screenshot_ap_multiplier_dialog.png.json
+++ b/resources/jp/live/screenshot_ap_multiplier_dialog.png.json
@@ -43,28 +43,6 @@
         "en": "require"
       }
     },
-    "2d6efdb5-633a-4251-ae5c-5d2b16638b9d": {
-      "type": "hint-point",
-      "props": {
-        "point": {
-          "kind": "point",
-          "x": 440,
-          "y": 319.70081874647497
-        }
-      },
-      "name": "Live.ApMultiplierDialog.PointMinus"
-    },
-    "43d64469-284d-41fd-b8ed-2fe7a6853367": {
-      "type": "hint-point",
-      "props": {
-        "point": {
-          "kind": "point",
-          "x": 837,
-          "y": 318.6373433970985
-        }
-      },
-      "name": "Live.ApMultiplierDialog.PointPlus"
-    },
     "ab7705f7-d074-4907-b461-bc943586b0bf": {
       "type": "hint-box",
       "props": {
@@ -77,6 +55,48 @@
         }
       },
       "name": "Live.ApMultiplierDialog.BoxApNumber"
+    },
+    "ddec2e5f-a019-4262-9198-45dfd129d789": {
+      "type": "prefab",
+      "prefab_id": "PjskButtonPrefab",
+      "name": "Live.ApMultiplierDialog.ButtonMinus",
+      "props": {
+        "template": {
+          "kind": "image",
+          "x1": 421.93772370688447,
+          "y1": 295.87990790919713,
+          "x2": 464.8377423909715,
+          "y2": 342.1197399914993
+        },
+        "fixed": true,
+        "button_type": "normal"
+      },
+      "variant_policy": {
+        "tw": "inherit",
+        "cn": "inherit",
+        "en": "inherit"
+      }
+    },
+    "71defbdc-203c-432f-917f-516561076c73": {
+      "type": "prefab",
+      "prefab_id": "PjskButtonPrefab",
+      "name": "Live.ApMultiplierDialog.ButtonPlus",
+      "props": {
+        "template": {
+          "kind": "image",
+          "x1": 815.3139465316559,
+          "y1": 296.31646584690515,
+          "x2": 860.471860935958,
+          "y2": 343.1201983204549
+        },
+        "fixed": true,
+        "button_type": "normal"
+      },
+      "variant_policy": {
+        "tw": "inherit",
+        "cn": "inherit",
+        "en": "inherit"
+      }
     }
   }
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,26 @@ class CliExecuteTests(unittest.TestCase):
 
     @mock.patch('iaa.main.manager.list', return_value=[])
     @mock.patch('iaa.main.IaaService')
+    def test_execute_auto_live_accepts_maximum_ap_multiplier(
+        self,
+        iaa_service_cls: mock.Mock,
+        _list_configs: mock.Mock,
+    ) -> None:
+        scheduler = mock.Mock()
+        iaa_service_cls.return_value = SimpleNamespace(scheduler=scheduler, config=mock.Mock())
+
+        action = parse_cli_action([
+            'invoke', 'auto_live',
+            '--ap-multiplier', 'maximum',
+        ])
+        code = execute_cli_action(action)
+
+        self.assertEqual(code, 0)
+        plan = scheduler.run_single.call_args.kwargs['kwargs']['plan']
+        self.assertEqual(plan.ap_multiplier, 'maximum')
+
+    @mock.patch('iaa.main.manager.list', return_value=[])
+    @mock.patch('iaa.main.IaaService')
     def test_execute_run_regular_calls_scheduler(
         self,
         iaa_service_cls: mock.Mock,

--- a/tests/test_live_auto_loop.py
+++ b/tests/test_live_auto_loop.py
@@ -46,25 +46,24 @@ class AutoLiveLoopTests(unittest.TestCase):
 
     @mock.patch('iaa.tasks.live.live.task_reporter', return_value=_FakeReporter())
     @mock.patch('iaa.tasks.live.live.Loop', return_value=[None])
-    def test_maximum_ap_multiplier_stops_when_value_no_longer_increases(
+    def test_maximum_ap_multiplier_stops_when_plus_button_is_disabled(
         self,
         _loop: mock.Mock,
         _task_reporter: mock.Mock,
     ) -> None:
-        device = mock.Mock()
-        ocr = mock.Mock()
         resources = mock.Mock()
-        values = iter([3, 4, 5, 5])
-        ocr.ocr.return_value.squash.return_value.numbers.side_effect = lambda: [next(values)]
+        plus_btn = mock.Mock()
         resources.Live.ApMultiplierDialog.TextTip.find.return_value = True
+        resources.Live.ApMultiplierDialog.ButtonPlus.q.return_value.find.side_effect = [plus_btn, plus_btn, None]
 
         with mock.patch.dict(
             live.__dict__,
-            {'device': device, 'ocr': ocr, 'R': resources, 'sleep': mock.Mock()},
+            {'R': resources, 'sleep': mock.Mock()},
         ):
             live._configure_ap_multiplier('maximum')
 
-        self.assertEqual(device.click.call_count, 3)
+        self.assertEqual(plus_btn.click.call_count, 2)
+        resources.Live.ApMultiplierDialog.ButtonPlus.q.assert_called_with(enabled=True)
         resources.Live.ApMultiplierDialog.ButtonConfirm.wait.return_value.click.assert_called_once()
 
 

--- a/tests/test_live_auto_loop.py
+++ b/tests/test_live_auto_loop.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest import mock
+
+from iaa.tasks.live import live
+from iaa.tasks.live.live import ListLoopPlan, solo_live
+
+
+class _FakePhase:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def step(self, _message: str) -> None:
+        raise AssertionError('phase.step should not run when no AP is available')
+
+
+class _FakeReporter:
+    def message(self, _message: str) -> None:
+        pass
+
+    def phase(self, _name: str, total: int | None = None) -> _FakePhase:
+        return _FakePhase()
+
+
+class AutoLiveLoopTests(unittest.TestCase):
+    @mock.patch('iaa.tasks.live.live.Loop', return_value=[None, None, None])
+    @mock.patch('iaa.tasks.live.live.task_reporter', return_value=_FakeReporter())
+    @mock.patch('iaa.tasks.live.live.go_home')
+    @mock.patch('iaa.tasks.live.live.start_auto_live', return_value=False)
+    @mock.patch('iaa.tasks.live.live._prepare_solo_live')
+    def test_list_loop_stops_when_start_auto_live_reports_no_ap(
+        self,
+        prepare_solo_live: mock.Mock,
+        start_auto_live: mock.Mock,
+        go_home: mock.Mock,
+        _task_reporter: mock.Mock,
+        _loop: mock.Mock,
+    ) -> None:
+        solo_live(ListLoopPlan(loop_count=None, play_mode='game_auto', ap_multiplier='maximum'))
+
+        prepare_solo_live.assert_called_once_with('list_next', None)
+        start_auto_live.assert_called_once()
+        go_home.assert_called_once()
+
+    @mock.patch('iaa.tasks.live.live.task_reporter', return_value=_FakeReporter())
+    @mock.patch('iaa.tasks.live.live.Loop', return_value=[None])
+    def test_maximum_ap_multiplier_stops_when_value_no_longer_increases(
+        self,
+        _loop: mock.Mock,
+        _task_reporter: mock.Mock,
+    ) -> None:
+        device = mock.Mock()
+        ocr = mock.Mock()
+        resources = mock.Mock()
+        values = iter([3, 4, 5, 5])
+        ocr.ocr.return_value.squash.return_value.numbers.side_effect = lambda: [next(values)]
+        resources.Live.ApMultiplierDialog.TextTip.find.return_value = True
+
+        with mock.patch.dict(
+            live.__dict__,
+            {'device': device, 'ocr': ocr, 'R': resources, 'sleep': mock.Mock()},
+        ):
+            live._configure_ap_multiplier('maximum')
+
+        self.assertEqual(device.click.call_count, 3)
+        resources.Live.ApMultiplierDialog.ButtonConfirm.wait.return_value.click.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_qt_auto_live.py
+++ b/tests/test_qt_auto_live.py
@@ -47,6 +47,19 @@ class AutoLivePayloadTests(unittest.TestCase):
         self.assertTrue(plan.debug_enabled)
         self.assertEqual(plan.ap_multiplier, 0)
 
+    def test_maximum_ap_multiplier_payload(self) -> None:
+        plan = auto_live_payload_to_plan(
+            {
+                'countMode': 'all',
+                'count': '',
+                'loopMode': 'list',
+                'playMode': 'game_auto',
+                'apMultiplier': 'maximum',
+            }
+        )
+        self.assertIsInstance(plan, ListLoopPlan)
+        self.assertEqual(plan.ap_multiplier, 'maximum')
+
     def test_invalid_count_raises(self) -> None:
         with self.assertRaises(ValueError):
             auto_live_payload_to_plan(


### PR DESCRIPTION
## 中文

这个 PR 为自动演出添加 `ap_multiplier = "maximum"` 支持，用于处理国际服在非活动期间 AP 倍率上限为 5 的情况。

内容包括：

- 添加 `maximum` AP 倍率选项
- 保留原有数字 `0-10` 行为
- 当使用 `maximum` 时，自动点击 `+` 直到加号按钮变为不可用
- 使用 PJSK 按钮 prefab 判断 AP 倍率加号按钮是否仍可点击
- 在 CLI、配置 schema、GUI 设置和自动演出弹窗中暴露该选项
- 修复列表循环自动演出在 AP 不足时继续循环的问题
- AP 不足停止列表循环时返回首页，避免影响后续任务
- 添加相关单元测试
- 在 GUI 中显示中文标签“最大值”，内部仍保存为 `maximum`

这个 PR 是针对 Global / EN 行为差异的运行时修复，不包含 EN 资源 variant 批量适配。

## English

This PR adds `ap_multiplier = "maximum"` support for auto live, mainly to handle Global / EN behavior where the AP multiplier is capped at 5 outside events.

Includes:

- Adds a `maximum` AP multiplier option
- Preserves existing numeric `0-10` behavior
- When `maximum` is selected, clicks `+` until the plus button becomes disabled
- Uses the PJSK button prefab to detect whether the AP multiplier plus button is still enabled
- Exposes the option through CLI, config schema, GUI settings, and the auto-live dialog
- Fixes list-loop auto live continuing after AP is unavailable
- Returns home when list-loop auto live stops due to insufficient AP, so later tasks are not left on the unit-select screen
- Adds focused tests
- Shows the option as `最大值` in the GUI while keeping the internal value as `maximum`

This PR is a runtime behavior fix for Global / EN compatibility and does not include bulk EN resource variant adaptation.