### PR TITLE
fix: support EN live result recovery / 支持 EN Live 结算返回流程

### DIFF
--- a/iaa/tasks/live/live.py
+++ b/iaa/tasks/live/live.py
@@ -91,8 +91,8 @@ CHALLENGE_AWARD_PREFABS: dict[ChallengeLiveAward, PrefabClass] = {
 def _skip():
     if server() == 'jp':
         device.click(1, 1)
-    elif server() == 'tw' or server() == 'cn':
-        # 台服要点侧边，点左上角没用
+    elif server() == 'tw' or server() == 'cn' or server() == 'en':
+        # TW/CN/EN need side taps; top-left taps do not reliably advance these screens.
         device.click(6, 346)
     else:
         raise NotImplementedError(f'Unsupported server: {server()}')
@@ -326,8 +326,7 @@ def _wait_live_end(live_mode: LiveMode) -> None:
 def _settle_to_home() -> bool:
     if at_home():
         return True
-    # 台服要点 OK 才行
-    if server() == 'tw' and R.Live.ButtonLiveCompletedOk.try_click():
+    if (server() == 'tw' or server() == 'en') and R.Live.ButtonLiveCompletedOk.try_click():
         logger.debug('Clicked live completed ok button.')
     _skip()
     sleep(0.6)


### PR DESCRIPTION
## 中文

这个 PR 为 EN / Global 服务器补充 Live 结算后的返回处理。

内容包括：

* 让 EN 服务器在 Live 结算返回流程中使用现有 TW / CN 的侧边点击逻辑
* 允许 EN 服务器在结算返回流程中点击 `R.Live.ButtonLiveCompletedOk`
* 避免 EN 在 `_skip()` 中因为不支持 `server="en"` 而抛出 `NotImplementedError`

这个 PR 不修改 transfer login / account linking，不修改资源文件或生成的 `R.py`，也不改变 JP / TW / CN 的现有行为。

## English

This PR adds EN / Global server support for live result recovery.

Includes:

* Makes EN use the existing TW / CN side-tap behavior during live result recovery
* Allows EN to click `R.Live.ButtonLiveCompletedOk` during result settlement
* Prevents EN from raising `NotImplementedError` in `_skip()` because `server="en"` was not supported

This PR does not change transfer login / account linking, does not modify resource files or generated `R.py`, and does not change existing JP / TW / CN behavior.
